### PR TITLE
add support for dependencies for `testSchemasTask`

### DIFF
--- a/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryPlugin.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryPlugin.kt
@@ -1,5 +1,6 @@
 package com.github.imflog.schema.registry
 
+import com.github.imflog.schema.registry.compatibility.CompatibilitySubjectExtension
 import com.github.imflog.schema.registry.compatibility.CompatibilityTask
 import com.github.imflog.schema.registry.compatibility.TEST_SCHEMAS_TASK
 import com.github.imflog.schema.registry.download.DOWNLOAD_SCHEMAS_TASK
@@ -25,7 +26,7 @@ class SchemaRegistryPlugin : Plugin<Project> {
                     RegisterSubjectExtension::class.java)
             val compatibilityExtension = extensions.create(
                     "compatibility",
-                    SubjectExtension::class.java)
+                    CompatibilitySubjectExtension::class.java)
 
             afterEvaluate {
                 tasks.create(

--- a/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilitySubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilitySubjectExtension.kt
@@ -1,0 +1,13 @@
+package com.github.imflog.schema.registry.compatibility
+
+open class CompatibilitySubjectExtension {
+    val subjects: ArrayList<Triple<String, String, List<String>>> = ArrayList()
+
+    fun subject(inputSubject: String, file: String) {
+        subjects.add(Triple(inputSubject, file, emptyList()))
+    }
+
+    fun subject(inputSubject: String, file: String, dependencies: List<String>) {
+        subjects.add(Triple(inputSubject, file, dependencies))
+    }
+}

--- a/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilityTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilityTask.kt
@@ -9,11 +9,15 @@ import org.gradle.api.tasks.TaskAction
 const val TEST_SCHEMAS_TASK = "testSchemasTask"
 
 open class CompatibilityTask : DefaultTask() {
+    init {
+        group = "registry"
+        description = "Test compatibility against registry"
+    }
 
     @Input
     lateinit var url: String
     @Input
-    lateinit var subjects: ArrayList<Pair<String, String>>
+    lateinit var subjects: List<Triple<String, String, List<String>>>
 
     @TaskAction
     fun testCompatibility() {

--- a/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/compatibility/CompatibilityTaskAction.kt
@@ -7,16 +7,16 @@ import java.io.File
 
 class CompatibilityTaskAction(
         val client: SchemaRegistryClient,
-        val subjects: ArrayList<Pair<String, String>>,
+        val subjects: List<Triple<String, String, List<String>>>,
         val rootDir: File) {
 
     private val logger = Logging.getLogger(CompatibilityTaskAction::class.java)
 
     fun run(): Int {
         var errorCount = 0
-        for ((subject, path) in subjects) {
+        for ((subject, path, dependencies) in subjects) {
             logger.debug("Loading schema for subject($subject) from $path.")
-            val parsedSchema: Schema = lookupSchemas(path)
+            val parsedSchema: Schema = parseSchemas(path, dependencies)
             val compatible = client.testCompatibility(subject, parsedSchema)
             if (compatible) {
                 logger.info("Schema $path is compatible with subject($subject)")
@@ -28,10 +28,23 @@ class CompatibilityTaskAction(
         return errorCount
     }
 
-    private fun lookupSchemas(path: String): Schema {
-
-        val schemaContent = File(rootDir, path).readText()
+    private fun parseSchemas(path: String, dependencies: List<String>): Schema {
         val parser = Schema.Parser()
+        loadDependencies(dependencies, parser)
+        return parseSchema(parser, path)
+    }
+
+    /**
+     * This adds all record names to the current parser known types.
+     */
+    private fun loadDependencies(dependencies: List<String>, parser: Schema.Parser) {
+        dependencies.reversed().forEach {
+            parseSchema(parser, it)
+        }
+    }
+
+    private fun parseSchema(parser: Schema.Parser, path: String): Schema {
+        val schemaContent = File(rootDir, path).readText()
         return parser.parse(schemaContent)
     }
 }


### PR DESCRIPTION
Very similar to #13 this adds the same type of support to
the `testSchemasTask`. Also added metadata for task so it
shows up when `./gradlew tasks` is called.