### PR TITLE
provide three schema providers (avro, protobug, json) to client

### DIFF
--- a/src/main/kotlin/com/github/imflog/schema/registry/RegistryClientWrapper.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/RegistryClientWrapper.kt
@@ -1,9 +1,12 @@
 package com.github.imflog.schema.registry
 
+import io.confluent.kafka.schemaregistry.SchemaProvider
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig
-
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider
 
 /**
  * This is a singleton.
@@ -14,14 +17,23 @@ object RegistryClientWrapper {
     private const val BASIC_AUTH_SOURCE: String = "USER_INFO"
 
     fun client(url: String, basicAuth: String): SchemaRegistryClient =
-        CachedSchemaRegistryClient(url, 100, getConfig(basicAuth))
+        CachedSchemaRegistryClient(
+            arrayListOf(url),
+            100,
+            getProviders(),
+            getConfig(basicAuth)
+        )
+
+    private fun getProviders(): List<SchemaProvider> {
+        return arrayListOf(AvroSchemaProvider(), ProtobufSchemaProvider(), JsonSchemaProvider())
+    }
 
     /**
      * Retrieves configuration from the plugin extension.
      * Note that BASIC_AUTH_CREDENTIALS_SOURCE is not configurable as the plugin only supports
      * a single schema registry URL, so there is no additional utility of the URL source.
      */
-    private fun getConfig(basicAuth: String): Map<String, String> = if (basicAuth == ":")
+    private fun getConfig(basicAuth: String): Map<String, Any?> = if (basicAuth == ":")
         mapOf()
     else
         mapOf(


### PR DESCRIPTION
this appears to work for my protobuf register/test tasks.