### PR TITLE
Update README.md to include jitpack mvn url

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ buildscript {
         maven {
             url "http://packages.confluent.io/maven/"
         }
+        maven {
+            url = uri("https://jitpack.io")
+        }
   }
     dependencies {
         classpath "com.github.imflog:kafka-schema-registry-gradle-plugin:X.X.X"


### PR DESCRIPTION
Trying to use the plugin in a project results in the following error:

```  
     > Could not find com.github.everit-org.json-schema:org.everit.json.schema:1.12.1.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/com/github/everit-org/json-schema/org.everit.json.schema/1.12.1/org.everit.json.schema-1.12.1.pom
       - http://packages.confluent.io/maven/com/github/everit-org/json-schema/org.everit.json.schema/1.12.1/org.everit.json.schema-1.12.1.pom
       - https://jcenter.bintray.com/com/github/everit-org/json-schema/org.everit.json.schema/1.12.1/org.everit.json.schema-1.12.1.pom
     Required by:
         project : > com.github.imflog:kafka-schema-registry-gradle-plugin:1.0.1 > io.confluent:kafka-json-schema-provider:6.0.0
```
Need to add the jitpack url to resolve the above dependency