### PR TITLE
Add quiet flag to global extension to avoid INFO logs

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -18,6 +18,6 @@ jobs:
           java-package: "jdk"
           architecture: "x64"
       - name: "Build with Gradle"
-        run: "./gradlew build --info"
+        run: "./gradlew build"
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -15,6 +15,6 @@ jobs:
           java-package: "jdk"
           architecture: "x64"
       - name: "Build with Gradle"
-        run: "./gradlew build --info"
+        run: "./gradlew build"
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         maven {
-            url "http://packages.confluent.io/maven/"
+            url "https://packages.confluent.io/maven/"
         }
         maven {
             url = uri("https://jitpack.io")
@@ -36,6 +36,18 @@ When you install the plugin, four tasks are added under `registry` group:
 
 What these tasks do and how to configure them is described in the following sections.
 
+### Global configuration
+```groovy
+schemaRegistry {
+    url = 'http://registry-url:8081/'
+    quiet = true 
+}
+```
+* `url` is where the script can reach the Schema Registry.
+* `quiet` is whether you want to disable "INFO" level logs.
+  This can be useful if you test the compatibility of a lot of schema.
+  Could be removed if https://github.com/gradle/gradle/issues/1010 is fixed.
+
 ### Download schemas
 Like the name of the task imply, this task is responsible for retrieving schemas from a schema registry.
 
@@ -54,8 +66,6 @@ schemaRegistry {
     }
 }
 ```
-You have to put the url where the script can reach the Schema Registry.
-
 You need to specify the pairs (subjectName, outputDir) for all the schemas you want to download. 
 
 ### Test schemas compatibility
@@ -72,8 +82,6 @@ schemaRegistry {
     }
 }
 ```
-You have to put the url where the script can reach the Schema Registry.
-
 You have to list all the (subject, avsc file path) pairs that you want to test. 
 
 If you have dependencies with other schemas required before the compatibility check,
@@ -95,8 +103,6 @@ schemaRegistry {
     }
 }
 ```
-You have to put the url where the script can reach the Schema Registry.
-
 You have to list all the (subject, avsc file path) pairs that you want to send.
 
 If you have dependencies with other schemas required before the compatibility check,
@@ -116,12 +122,9 @@ schemaRegistry {
     }
 }
 ```
-
 See the Confluent
 [Schema Registry documentation](https://docs.confluent.io/current/schema-registry/avro.html#compatibility-types)
 for more information on valid compatibility levels.
-
-You have to put the URL where the script can reach the Schema Registry.
 
 You have to list the (subject, compatibility-level) 
 
@@ -166,8 +169,8 @@ When using the plugin, a default version of the confluent Schema registry is use
 The 5.5.X version of the schema-registry introduced changes that made the older version of the plugin obsolete.
 
 It was easier to introduce all the changes in one shot instead of supporting both version. Here is what it implies for users:
-* plugin versions above 1.X.X support the confluent version 5.5.X (Avro / Json / Protobuf)
-* plugin versions should supports anything below 5.4.X
+* plugin versions above 1.X.X support the confluent version > 5.5.X (Avro / Json / Protobuf)
+* plugin versions should support anything below 5.4.X
 
 We are not strictly following confluent version so if you need to change the confluent version for some reason,
 take a look at [examples/override-confluent-version](examples/override-confluent-version).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.imflog"
-version = "1.3.1-SNAPSHOT"
+version = "1.4.0-SNAPSHOT"
 
 plugins {
     kotlin("jvm") version "1.4.31"
@@ -28,7 +28,9 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
     implementation(platform("io.confluent:kafka-schema-registry-parent:$confluentVersion"))
-    implementation("io.confluent", "kafka-schema-registry")
+    implementation("io.confluent", "kafka-schema-registry") {
+        exclude("org.slf4j", "slf4j-log4j12")
+    }
     implementation("io.confluent", "kafka-json-schema-provider")
     implementation("io.confluent", "kafka-protobuf-provider")
 }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,11 +1,8 @@
 buildscript {
     repositories {
-        jcenter()
+        gradlePluginPortal()
         maven {
             url = uri("https://packages.confluent.io/maven/")
-        }
-        maven {
-            url = uri("https://plugins.gradle.org/m2/")
         }
         maven {
             url = uri("https://jitpack.io")

--- a/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryExtension.kt
@@ -13,4 +13,8 @@ open class SchemaRegistryExtension(objects: ObjectFactory) {
         // Default value
         convention("http://localhost:8081")
     }
+
+    val quiet: Property<Boolean> = objects.property(Boolean::class.java).apply {
+        convention(false)
+    }
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryPlugin.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/SchemaRegistryPlugin.kt
@@ -51,6 +51,7 @@ class SchemaRegistryPlugin : Plugin<Project> {
             tasks.register(DownloadTask.TASK_NAME, DownloadTask::class.java)
                 .configure {
                     it.url.set(globalExtension.url)
+                    it.quietLogging.set(globalExtension.quiet)
                     it.basicAuth.set(basicAuthExtension.basicAuth)
                     it.ssl.set(sslExtension.configs)
                     it.subjects.set(downloadExtension.subjects)
@@ -59,6 +60,7 @@ class SchemaRegistryPlugin : Plugin<Project> {
             tasks.register(RegisterSchemasTask.TASK_NAME, RegisterSchemasTask::class.java)
                 .configure {
                     it.url.set(globalExtension.url)
+                    it.quietLogging.set(globalExtension.quiet)
                     it.basicAuth.set(basicAuthExtension.basicAuth)
                     it.ssl.set(sslExtension.configs)
                     it.subjects.set(registerExtension.subjects)
@@ -67,6 +69,7 @@ class SchemaRegistryPlugin : Plugin<Project> {
             tasks.register(CompatibilityTask.TASK_NAME, CompatibilityTask::class.java)
                 .configure {
                     it.url.set(globalExtension.url)
+                    it.quietLogging.set(globalExtension.quiet)
                     it.basicAuth.set(basicAuthExtension.basicAuth)
                     it.ssl.set(sslExtension.configs)
                     it.subjects.set(compatibilityExtension.subjects)

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/BaseTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/BaseTaskAction.kt
@@ -5,10 +5,12 @@ import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import java.io.File
+import org.gradle.api.logging.Logger
 
 abstract class BaseTaskAction(
     val client: SchemaRegistryClient,
-    val rootDir: File
+    val rootDir: File,
+    val quietLogging: Boolean
 ) {
 
     fun parseSchemaFromFile(schemaPath: String, schemaType: String, dependencies: List<SchemaReference>): ParsedSchema {
@@ -25,4 +27,13 @@ abstract class BaseTaskAction(
         client.parseSchema(schemaType, schemaContent, dependencies).orElseThrow {
             SchemaParsingException(subject, schemaType)
         }
+
+    /**
+     * Utility method that checks if the quiet logging is activated before logging.
+     * This is needed because we cannot setup a log level per task.
+     * See https://github.com/gradle/gradle/issues/1010
+     */
+    fun Logger.infoIfNotQuiet(message: String) {
+        if (!quietLogging) info(message)
+    }
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/BaseTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/BaseTaskAction.kt
@@ -5,12 +5,12 @@ import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import java.io.File
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
 
 abstract class BaseTaskAction(
     val client: SchemaRegistryClient,
     val rootDir: File,
-    val quietLogging: Boolean
+    private val quietLogging: Boolean
 ) {
 
     fun parseSchemaFromFile(schemaPath: String, schemaType: String, dependencies: List<SchemaReference>): ParsedSchema {
@@ -34,6 +34,6 @@ abstract class BaseTaskAction(
      * See https://github.com/gradle/gradle/issues/1010
      */
     fun Logger.infoIfNotQuiet(message: String) {
-        if (!quietLogging) info(message)
+        if (!quietLogging) this.info(message)
     }
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTask.kt
@@ -34,12 +34,16 @@ open class CompatibilityTask @Inject constructor(objects: ObjectFactory) : Defau
     @Input
     val subjects: ListProperty<CompatibilitySubject> = objects.listProperty(CompatibilitySubject::class.java)
 
+    @Input
+    val quietLogging: Property<Boolean> = objects.property(Boolean::class.java)
+
     @TaskAction
     fun testCompatibility() {
         val errorCount = CompatibilityTaskAction(
             RegistryClientWrapper.client(url.get(), basicAuth.get(), ssl.get()),
             project.rootDir,
-            subjects.get()
+            subjects.get(),
+            quietLogging.get()
         ).run()
         if (errorCount > 0) {
             throw GradleScriptException("$errorCount schemas not compatible, see logs for details.", Throwable())

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -4,15 +4,16 @@ import com.github.imflog.schema.registry.tasks.BaseTaskAction
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors
-import org.gradle.api.logging.Logging
 import java.io.File
 import java.io.IOException
+import org.gradle.api.logging.Logging
 
 class CompatibilityTaskAction(
     client: SchemaRegistryClient,
     rootDir: File,
-    private val subjects: List<CompatibilitySubject>
-) : BaseTaskAction(client, rootDir) {
+    private val subjects: List<CompatibilitySubject>,
+    quietLogging: Boolean
+) : BaseTaskAction(client, rootDir, quietLogging) {
 
     private val logger = Logging.getLogger(CompatibilityTaskAction::class.java)
 
@@ -46,7 +47,7 @@ class CompatibilityTaskAction(
                 }
             }
             if (isCompatible) {
-                logger.info("Schema $path is compatible with subject: $subject")
+                logger.infoIfNotQuiet("Schema $path is compatible with subject: $subject")
             } else {
                 logger.error("Schema $path is not compatible with subject: $subject")
                 errorCount++

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTask.kt
@@ -35,12 +35,16 @@ open class DownloadTask @Inject constructor(objects: ObjectFactory) : DefaultTas
     @Input
     val ssl: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 
+    @Input
+    val quietLogging: Property<Boolean> = objects.property(Boolean::class.java)
+
     @TaskAction
     fun downloadSchemas() {
         val errorCount = DownloadTaskAction(
             RegistryClientWrapper.client(url.get(), basicAuth.get(), ssl.get()),
             project.rootDir,
-            subjects.get()
+            subjects.get(),
+            quietLogging.get()
         ).run()
         if (errorCount > 0) {
             throw GradleScriptException("$errorCount schemas not downloaded, see logs for details", Throwable())

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSchemasTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSchemasTask.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.register
 
 import com.github.imflog.schema.registry.RegistryClientWrapper
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.model.ObjectFactory
@@ -9,7 +10,6 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
-import javax.inject.Inject
 
 open class RegisterSchemasTask @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
@@ -34,12 +34,16 @@ open class RegisterSchemasTask @Inject constructor(objects: ObjectFactory) : Def
     @Input
     val subjects: ListProperty<RegisterSubject> = objects.listProperty(RegisterSubject::class.java)
 
+    @Input
+    val quietLogging: Property<Boolean> = objects.property(Boolean::class.java)
+
     @TaskAction
     fun registerSchemas() {
         val errorCount = RegisterTaskAction(
             RegistryClientWrapper.client(url.get(), basicAuth.get(), ssl.get()),
             project.rootDir,
-            subjects.get()
+            subjects.get(),
+            quietLogging.get()
         ).run()
         if (errorCount > 0) {
             throw GradleScriptException("$errorCount schemas not registered, see logs for details", Throwable())

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -9,8 +9,9 @@ import java.io.File
 class RegisterTaskAction(
     client: SchemaRegistryClient,
     rootDir: File,
-    private val subjects: List<RegisterSubject>
-) : BaseTaskAction(client, rootDir) {
+    private val subjects: List<RegisterSubject>,
+    quietLogging: Boolean
+) : BaseTaskAction(client, rootDir, quietLogging) {
 
     private val logger = Logging.getLogger(RegisterTaskAction::class.java)
 
@@ -19,7 +20,7 @@ class RegisterTaskAction(
         subjects.forEach { (subject, path, type, dependencies) ->
             try {
                 val parsedSchema = parseSchemaFromFile(path, type, dependencies)
-                logger.debug("Calling register ($subject, $path)")
+                logger.infoIfNotQuiet("Registering $subject (from $path)")
                 client.register(subject, parsedSchema)
             } catch (e: Exception) {
                 logger.error("Could not register schema for '$subject'", e)

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
@@ -68,7 +68,8 @@ class CompatibilityTaskActionTest {
         val errorCount = CompatibilityTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then
@@ -153,7 +154,8 @@ class CompatibilityTaskActionTest {
         val errorCount = CompatibilityTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then
@@ -197,7 +199,8 @@ class CompatibilityTaskActionTest {
         val errorCount = CompatibilityTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then
@@ -237,7 +240,8 @@ class CompatibilityTaskActionTest {
         val errorCount = CompatibilityTaskAction(
             spySchemaRegistry,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
@@ -72,7 +72,8 @@ class DownloadTaskActionTest {
             arrayListOf(
                 DownloadSubject(testSubject, outputDir),
                 DownloadSubject(fooSubject, outputDir)
-            )
+            ),
+            false
         ).run()
 
         // then
@@ -143,7 +144,8 @@ class DownloadTaskActionTest {
             folderRule.root,
             arrayListOf(
                 DownloadSubject("te.*", outputDir, null, true)
-            )
+            ),
+            false
         ).run()
 
         // then
@@ -189,7 +191,8 @@ class DownloadTaskActionTest {
         val errorCount = DownloadTaskAction(
             registryClient,
             folderRule.root,
-            arrayListOf(DownloadSubject(subject, outputDir))
+            arrayListOf(DownloadSubject(subject, outputDir)),
+            false
         ).run()
 
         // then
@@ -223,7 +226,8 @@ class DownloadTaskActionTest {
             arrayListOf(
                 DownloadSubject(invalidSubjectPattern, outputDir, null, true),
                 DownloadSubject("test", outputDir)
-            )
+            ),
+            false
         ).run()
 
         // then
@@ -275,7 +279,8 @@ class DownloadTaskActionTest {
             folderRule.root,
             arrayListOf(
                 DownloadSubject("test", outputDir, v1Id)
-            )
+            ),
+            false
         ).run()
 
         // Then

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -53,7 +53,8 @@ class RegisterTaskActionTest {
         val errorCount = RegisterTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then
@@ -100,7 +101,8 @@ class RegisterTaskActionTest {
         val errorCount = RegisterTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then
@@ -184,7 +186,8 @@ class RegisterTaskActionTest {
         val errorCount = RegisterTaskAction(
             registryClient,
             folderRule.root,
-            subjects
+            subjects,
+            false
         ).run()
 
         // then


### PR DESCRIPTION
Add a `quiet` flag to global extension. 
It defaults to `false` to avoid impact on previous versions.

Fix #59 

CC @Slav4ik