### PR TITLE
introduce Subject replacing CompatibilitySubject and RegisterSubject

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -12,11 +12,6 @@ jobs:
     strategy:
       matrix:
         kafka_version: [
-          # This version is KO but probably just a container issue.
-          # See https://github.com/testcontainers/testcontainers-java/issues/6423
-          # Disabling it for now
-          # "5.5.1",
-
           "6.2.6",
           "7.2.2",
           "7.3.1"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,6 +1,6 @@
 name: "PR"
 
-on: ["pull_request"]
+on: [ "pull_request" ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ buildscript {
         classpath "com.github.imflog:kafka-schema-registry-gradle-plugin:X.X.X-SNAPSHOT"
     }
 }
+
+apply plugin: "com.github.imflog.kafka-schema-registry-gradle-plugin"
 ```
 
 ## Thanks to all the sponsors :pray:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Download](https://img.shields.io/gradle-plugin-portal/v/com.github.imflog.kafka-schema-registry-gradle-plugin)](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin)
 ![Github Actions](https://github.com/ImFlog/schema-registry-plugin/workflows/Master/badge.svg)
 
 # Schema-registry-plugin
@@ -5,8 +6,49 @@ The aim of this plugin is to adapt the [Confluent schema registry maven plugin](
 
 ## Usage
 
-The plugin requires external dependencies coming from Confluent and Jitpack repositories.
-You can follow the instructions on the [gradle plugin portal](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin).
+As the plugin relies on packages developed by confluent you need to add the `https://packages.confluent.io/maven/` repository
+to your `buildscript`:
+
+<div class="tabbed-code-block">
+  <details>
+    <summary>Groovy</summary>
+
+```groovy
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        maven {
+            url = "https://packages.confluent.io/maven/"
+        }
+    }
+}
+plugins {
+  id "com.github.imflog.kafka-schema-registry-gradle-plugin" version "X.X.X"
+}
+```
+
+  </details>
+  <details>
+    <summary>Kotlin</summary>
+
+```kotlin
+buildscript {
+  repositories {
+    gradlePluginPortal()
+    maven {
+        url = uri("https://packages.confluent.io/maven/")
+    }
+  }
+}
+plugins {
+  id("com.github.imflog.kafka-schema-registry-gradle-plugin") version "X.X.X"
+}
+```
+
+  </details>
+</div>
+
+Where "X.X.X" is the current version, see [gradle plugin portal](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin) for details.
 
 ## Tasks
 When you install the plugin, four tasks are added under `registry` group:
@@ -201,7 +243,7 @@ schemaRegistry {
 Valid key values are listed here: [org.apache.kafka.common.config.SslConfigs](https://github.com/confluentinc/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java)
 
 ### Examples
-See the [examples](examples) directory to see the plugin in action !
+Detailed examples can be found in the [examples directory](examples).
 
 ## Version compatibility
 When using the plugin, a default version of the confluent Schema registry is use.
@@ -220,9 +262,9 @@ take a look at [examples/override-confluent-version](examples/override-confluent
 In order to customize the Kafka version to run in integration tests,
 you can specify the ENV VAR KAFKA_VERSION with the version that you want to test upon.
 The library is tested with the following versions:
-* 5.5.1
 * 6.2.6
-* 7.2.1 (by default if no env_var is passed)
+* 7.2.2
+* 7.3.1 (by default if no env_var is passed)
 
 PS: If you are running an ARM computer (like apple M1),
 you can add the `.arm64` suffix to the version to run ARM container and speed up tests.
@@ -254,3 +296,6 @@ buildscript {
 }
 ```
 
+## Thanks to all the sponsors :pray:
+
+<a href="https://github.com/marktros"><img style="border-radius: 50%;" src="https://github.com/marktros.png" width="60px" alt="Mark Ethan Trostler" /></a>

--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ you can call the `addLocalReference("name", "/a/path")`,
 this will add a reference from a local file and inline it in the schema registry call.
 The addLocalReference calls can be chained.
 
+Notes:
+* If you want to reuse Subjects with the register task you can define a `Subject` object like so:
+  ```groovy
+  def mySubject = Subject("avroSubject", "/path.avsc", "AVRO")
+  
+  schemaRegistry {
+    url = 'http://registry-url:8081'
+    register {
+      subject(mySubject)
+    }
+    compatibility {
+      subject(mySubject)
+    }
+  }
+  ```
+
 #### Avro
 Mixing local and remote references is perfectly fine for Avro without specific configurations.
 
@@ -163,8 +179,6 @@ schemaRegistry {
     }
 }
 ```
-You have to list all the (subject, avsc file path) pairs that you want to send.
-
 If you have references to other schemas required before the register,
 you can call the `addReference("name", "subject", version)`, this will add a reference to use from the registry.
 The addReference calls can be chained.
@@ -174,8 +188,23 @@ you can call the `addLocalReference("name", "/a/path")`,
 this will add a reference from a local file and inline it in the schema registry call.
 The addLocalReference calls can be chained.
 
-A registered.csv file will be created with the following format `subject, path, id` 
+Notes:
+* A registered.csv file will be created with the following format `subject, path, id` 
 if you need information about the registered id.
+* If you want to reuse Subjects with the compatibility task you can define a `Subject` object like so:
+  ```groovy
+  def mySubject = Subject("avroSubject", "/path.avsc", "AVRO")
+  
+  schemaRegistry {
+    url = 'http://registry-url:8081'
+    register {
+      subject(mySubject)
+    }
+    compatibility {
+      subject(mySubject)
+    }
+  }
+  ```
 
 #### Avro
 Mixing local and remote references is perfectly fine for Avro without specific configurations.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://packages.confluent.io/maven/")
-    maven("https://jitpack.io")
 }
 
 // Dependencies versions

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 group = "com.github.imflog"
 version = "1.9.2-SNAPSHOT"
 
+
 plugins {
-    kotlin("jvm") version "1.8.0"
+    kotlin("jvm") version "1.8.10"
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "1.1.0"
     id("maven-publish")
@@ -17,7 +18,7 @@ repositories {
 }
 
 // Dependencies versions
-val kotlinVersion = "1.8.0"
+val kotlinVersion = "1.8.10"
 val confluentVersion = "7.3.1"
 dependencies {
     implementation(gradleApi())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ version = "1.9.2-SNAPSHOT"
 
 
 plugins {
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.8.20"
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "1.1.0"
     id("maven-publish")
@@ -17,7 +17,7 @@ repositories {
 }
 
 // Dependencies versions
-val kotlinVersion = "1.8.10"
+val kotlinVersion = "1.8.20"
 val confluentVersion = "7.3.1"
 dependencies {
     implementation(gradleApi())

--- a/examples/avro-kts/build.gradle.kts
+++ b/examples/avro-kts/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    id("com.github.imflog.kafka-schema-registry-gradle-plugin")
+}
+
+schemaRegistry {
+    url.set("http://localhost:8081")
+    quiet.set(false)
+    outputDirectory.set("schemas/avro/results/")
+
+    register {
+        subject("company", "schemas/avro/company.avsc", "AVRO")
+                .addLocalReference("Address", "schemas/avro/location-address.avsc")
+        subject("user", "schemas/avro/user.avsc", "AVRO")
+                .addReference("company", "company", -1)
+        subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
+        subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
+    }
+
+    config {
+        subject("company", "FULL_TRANSITIVE")
+        subject("user", "FULL_TRANSITIVE")
+        subject("location-address", "FULL_TRANSITIVE")
+        subject("location-latlong", "FULL_TRANSITIVE")
+    }
+
+    download {
+        subject("company", "schemas/avro/downloaded")
+        subject("user", "schemas/avro/downloaded")
+        subjectPattern("location.*", "schemas/avro/downloaded/location")
+    }
+
+    compatibility {
+        subject("company", "schemas/avro/company_v2.avsc", "AVRO")
+                .addLocalReference("Address", "schemas/avro/location-address.avsc")
+        subject("user", "schemas/avro/user.avsc", "AVRO")
+                .addReference("company", "company", -1)
+        subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
+        subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
+    }
+}

--- a/examples/avro/build.gradle
+++ b/examples/avro/build.gradle
@@ -1,6 +1,10 @@
 plugins {
     id "com.github.imflog.kafka-schema-registry-gradle-plugin"
 }
+import com.github.imflog.schema.registry.Subject
+
+Subject locationAddressSubject = new Subject('location-address', 'schemas/avro/location-address.avsc', 'AVRO')
+Subject locationCoordSubject = new Subject('location-latlong', 'schemas/avro/location-latlong.avsc', 'AVRO')
 
 schemaRegistry {
     url = 'http://localhost:8081'
@@ -12,8 +16,8 @@ schemaRegistry {
                 .addLocalReference("Address", "schemas/avro/location-address.avsc")
         subject('user', 'schemas/avro/user.avsc', 'AVRO')
                 .addReference('company', 'company', -1)
-        subject('location-address', 'schemas/avro/location-address.avsc', 'AVRO')
-        subject('location-latlong', 'schemas/avro/location-latlong.avsc', 'AVRO')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 
     config {
@@ -34,7 +38,7 @@ schemaRegistry {
                 .addLocalReference("Address", "schemas/avro/location-address.avsc")
         subject('user', 'schemas/avro/user.avsc', 'AVRO')
                 .addReference('company', 'company', -1)
-        subject('location-address', 'schemas/avro/location-address.avsc', 'AVRO')
-        subject('location-latlong', 'schemas/avro/location-latlong.avsc', 'AVRO')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,15 +1,18 @@
 buildscript {
     repositories {
         gradlePluginPortal()
+        mavenLocal()
         maven {
             url = uri("https://packages.confluent.io/maven/")
         }
     }
+
+    dependencies {
+        classpath("com.github.imflog:kafka-schema-registry-gradle-plugin:1.9.2-SNAPSHOT")
+    }
 }
 
 plugins {
-    // Set it to false to let subproject apply the plugin
-    id("com.github.imflog.kafka-schema-registry-gradle-plugin") version "1.9.1" apply false
     id("com.avast.gradle.docker-compose") version "0.16.8" apply true
 }
 

--- a/examples/json/build.gradle
+++ b/examples/json/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id "com.github.imflog.kafka-schema-registry-gradle-plugin"
 }
 
+import com.github.imflog.schema.registry.Subject
+
+Subject locationAddressSubject = new Subject('location-address', 'schemas/json/location-address.json', 'JSON')
+Subject locationCoordSubject = new Subject('location-latlong', 'schemas/json/location-latlong.json', 'JSON')
+
 schemaRegistry {
     url = 'http://localhost:8081'
     quiet = false
@@ -12,8 +17,8 @@ schemaRegistry {
             .addLocalReference('Address', 'schemas/json/location-address.json')
         subject('user', 'schemas/json/user.json', 'JSON')
             .addReference('company', 'company', -1)
-        subject('location-address', 'schemas/json/location-address.json', 'JSON')
-        subject('location-latlong', 'schemas/json/location-latlong.json', 'JSON')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 
     config {
@@ -34,7 +39,7 @@ schemaRegistry {
             .addLocalReference("address", "schemas/json/location-address.json")
         subject('user', 'schemas/json/user.json', 'JSON')
             .addReference('company', 'company', -1)
-        subject('location-address', 'schemas/json/location-address.json', 'JSON')
-        subject('location-latlong', 'schemas/json/location-latlong.json', 'JSON')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 }

--- a/examples/protobuf/build.gradle
+++ b/examples/protobuf/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id "com.github.imflog.kafka-schema-registry-gradle-plugin"
 }
 
+import com.github.imflog.schema.registry.Subject
+
+Subject locationAddressSubject = new Subject('location-address', 'schemas/protobuf/com/example/location-address.proto', 'PROTOBUF')
+Subject locationCoordSubject = new Subject('location-latlong', 'schemas/protobuf/com/example/location-latlong.proto', 'PROTOBUF')
+
 schemaRegistry {
     url = 'http://localhost:8081'
     quiet = false
@@ -11,8 +16,8 @@ schemaRegistry {
         subject('company', 'schemas/protobuf/com/example/company.proto', 'PROTOBUF')
         subject('user', 'schemas/protobuf/com/example/user.proto', 'PROTOBUF')
             .addReference('company', 'company', 1)
-        subject('location-address', 'schemas/protobuf/com/example/location-address.proto', 'PROTOBUF')
-        subject('location-latlong', 'schemas/protobuf/com/example/location-latlong.proto', 'PROTOBUF')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 
     config {
@@ -32,7 +37,7 @@ schemaRegistry {
         subject('company', 'schemas/protobuf/com/example/company_v2.proto', 'PROTOBUF')
         subject('user', 'schemas/protobuf/com/example/user.proto', 'PROTOBUF')
             .addReference('company', 'company', 1)
-        subject('location-address', 'schemas/protobuf/com/example/location-address.proto', 'PROTOBUF')
-        subject('location-latlong', 'schemas/protobuf/com/example/location-latlong.proto', 'PROTOBUF')
+        subject(locationAddressSubject)
+        subject(locationCoordSubject)
     }
 }

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -1,2 +1,9 @@
 rootProject.name = "examples"
-include("avro", "protobuf", "json", "override-confluent-version", "ssl")
+include(
+    "avro",
+    "avro-kts",
+    "protobuf",
+    "json",
+    "override-confluent-version",
+    "ssl"
+)

--- a/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
@@ -59,20 +59,10 @@ abstract class KafkaTestContainersUtils {
                 )
         }
 
-        @JvmStatic
-        @BeforeAll
-        fun startContainers() {
+        init {
             kafkaContainer.start()
             schemaRegistryContainer.start()
             schemaRegistrySslContainer.start()
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun stopContainers() {
-            schemaRegistryContainer.stop()
-            schemaRegistrySslContainer.stop()
-            kafkaContainer.stop()
         }
     }
 

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -1,0 +1,21 @@
+package com.github.imflog.schema.registry
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+
+data class Subject(
+    val inputSubject: String,
+    val file: String,
+    val type: SchemaType,
+    val references: MutableList<SchemaReference> = mutableListOf(),
+    val localReferences: MutableList<LocalReference> = mutableListOf()
+) {
+    fun addReference(name: String, subject: String, version: Int): Subject {
+        references.add(SchemaReference(name, subject, version))
+        return this
+    }
+
+    fun addLocalReference(name: String, path: String): Subject {
+        localReferences.add(LocalReference(name, path))
+        return this
+    }
+}

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -5,10 +5,11 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 data class Subject(
     val inputSubject: String,
     val file: String,
-    val type: SchemaType,
-    val references: MutableList<SchemaReference> = mutableListOf(),
-    val localReferences: MutableList<LocalReference> = mutableListOf()
+    val type: String
 ) {
+    val references: MutableList<SchemaReference> = mutableListOf()
+    val localReferences: MutableList<LocalReference> = mutableListOf()
+
     fun addReference(name: String, subject: String, version: Int): Subject {
         references.add(SchemaReference(name, subject, version))
         return this
@@ -18,4 +19,8 @@ data class Subject(
         localReferences.add(LocalReference(name, path))
         return this
     }
+
+    // Used for data class destructuring
+    operator fun component4() = references
+    operator fun component5() = localReferences
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilitySubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilitySubjectExtension.kt
@@ -1,10 +1,8 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
-import com.github.imflog.schema.registry.LocalReference
-import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 
@@ -13,7 +11,7 @@ open class CompatibilitySubjectExtension(objects: ObjectFactory) {
         const val EXTENSION_NAME = "compatibility"
     }
 
-    val subjects: ListProperty<CompatibilitySubject> = objects.listProperty(CompatibilitySubject::class.java)
+    val subjects: ListProperty<Subject> = objects.listProperty(Subject::class.java)
 
     fun subject(inputSubject: String, file: String) = subject(inputSubject, file, AvroSchema.TYPE)
 
@@ -21,27 +19,11 @@ open class CompatibilitySubjectExtension(objects: ObjectFactory) {
         inputSubject: String,
         file: String,
         type: String
-    ): CompatibilitySubject {
-        val compatibilitySubject = CompatibilitySubject(inputSubject, file, type.toSchemaType())
+    ): Subject {
+        val compatibilitySubject = Subject(inputSubject, file, type.toSchemaType())
         subjects.add(compatibilitySubject)
         return compatibilitySubject
     }
-}
 
-data class CompatibilitySubject(
-    val inputSubject: String,
-    val file: String,
-    val type: SchemaType,
-    val references: MutableList<SchemaReference> = mutableListOf(),
-    val localReferences: MutableList<LocalReference> = mutableListOf()
-) {
-    fun addReference(name: String, subject: String, version: Int): CompatibilitySubject {
-        references.add(SchemaReference(name, subject, version))
-        return this
-    }
-
-    fun addLocalReference(name: String, path: String): CompatibilitySubject {
-        localReferences.add(LocalReference(name, path))
-        return this
-    }
+    fun subject(subject: Subject) = subject.apply { subjects.add(subject) }
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilitySubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilitySubjectExtension.kt
@@ -20,7 +20,7 @@ open class CompatibilitySubjectExtension(objects: ObjectFactory) {
         file: String,
         type: String
     ): Subject {
-        val compatibilitySubject = Subject(inputSubject, file, type.toSchemaType())
+        val compatibilitySubject = Subject(inputSubject, file, type)
         subjects.add(compatibilitySubject)
         return compatibilitySubject
     }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTask.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
 import com.github.imflog.schema.registry.RegistryClientWrapper
+import com.github.imflog.schema.registry.Subject
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.model.ObjectFactory
@@ -32,7 +33,7 @@ open class CompatibilityTask @Inject constructor(objects: ObjectFactory) : Defau
     val ssl: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 
     @Input
-    val subjects: ListProperty<CompatibilitySubject> = objects.listProperty(CompatibilitySubject::class.java)
+    val subjects: ListProperty<Subject> = objects.listProperty(Subject::class.java)
 
     @TaskAction
     fun testCompatibility() {

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
 import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
+import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
@@ -12,7 +13,7 @@ import java.io.IOException
 class CompatibilityTaskAction(
     private val client: SchemaRegistryClient,
     private val rootDir: File,
-    private val subjects: List<CompatibilitySubject>,
+    private val subjects: List<Subject>,
 ) {
 
     private val logger = Logging.getLogger(CompatibilityTaskAction::class.java)

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -3,6 +3,7 @@ package com.github.imflog.schema.registry.tasks.compatibility
 import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
 import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
+import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors
@@ -24,7 +25,7 @@ class CompatibilityTaskAction(
             logger.debug("Loading schema for subject($subject) from $path.")
             val isCompatible = try {
                 val parsedSchema = SchemaParser
-                    .provide(type, client, rootDir)
+                    .provide(type.toSchemaType(), client, rootDir)
                     .parseSchemaFromFile(
                         subject,
                         path,

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSchemasTask.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSchemasTask.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.register
 
 import com.github.imflog.schema.registry.RegistryClientWrapper
+import com.github.imflog.schema.registry.Subject
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleScriptException
 import org.gradle.api.model.ObjectFactory
@@ -33,7 +34,7 @@ abstract class RegisterSchemasTask @Inject constructor(objects: ObjectFactory) :
     val ssl: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 
     @Input
-    val subjects: ListProperty<RegisterSubject> = objects.listProperty(RegisterSubject::class.java)
+    val subjects: ListProperty<Subject> = objects.listProperty(Subject::class.java)
 
     @Input
     @Optional

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSubjectExtension.kt
@@ -20,7 +20,7 @@ open class RegisterSubjectExtension(objects: ObjectFactory) {
         file: String,
         type: String
     ): Subject {
-        val subject = Subject(inputSubject, file, type.toSchemaType())
+        val subject = Subject(inputSubject, file, type)
         subjects.add(subject)
         return subject
     }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterSubjectExtension.kt
@@ -1,11 +1,8 @@
 package com.github.imflog.schema.registry.tasks.register
 
-import com.github.imflog.schema.registry.LocalReference
-import com.github.imflog.schema.registry.MixedReferenceException
-import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 
@@ -14,7 +11,7 @@ open class RegisterSubjectExtension(objects: ObjectFactory) {
         const val EXTENSION_NAME = "register"
     }
 
-    val subjects: ListProperty<RegisterSubject> = objects.listProperty(RegisterSubject::class.java)
+    val subjects: ListProperty<Subject> = objects.listProperty(Subject::class.java)
 
     fun subject(inputSubject: String, file: String) = subject(inputSubject, file, AvroSchema.TYPE)
 
@@ -22,27 +19,11 @@ open class RegisterSubjectExtension(objects: ObjectFactory) {
         inputSubject: String,
         file: String,
         type: String
-    ): RegisterSubject {
-        val subject = RegisterSubject(inputSubject, file, type.toSchemaType())
+    ): Subject {
+        val subject = Subject(inputSubject, file, type.toSchemaType())
         subjects.add(subject)
         return subject
     }
-}
 
-data class RegisterSubject(
-    val inputSubject: String,
-    val file: String,
-    val type: SchemaType,
-    val references: MutableList<SchemaReference> = mutableListOf(),
-    val localReferences: MutableList<LocalReference> = mutableListOf()
-) {
-    fun addReference(name: String, subject: String, version: Int): RegisterSubject {
-        references.add(SchemaReference(name, subject, version))
-        return this
-    }
-
-    fun addLocalReference(name: String, path: String): RegisterSubject {
-        localReferences.add(LocalReference(name, path))
-        return this
-    }
+    fun subject(subject: Subject) = subject.apply { subjects.add(subject) }
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -5,6 +5,7 @@ import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
 import com.github.imflog.schema.registry.SchemaType
 import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
+import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import org.gradle.api.logging.Logging
@@ -28,7 +29,7 @@ class RegisterTaskAction(
         writeOutputFileHeader()
         subjects.forEach { (subject, path, type, references, localReferences) ->
             try {
-                val schemaId = registerSchema(subject, path, type, references, localReferences)
+                val schemaId = registerSchema(subject, path, type.toSchemaType(), references, localReferences)
                 writeRegisteredSchemaOutput(subject, path, schemaId)
             } catch (e: Exception) {
                 logger.error("Could not register schema for '$subject'", e)

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -3,6 +3,7 @@ package com.github.imflog.schema.registry.tasks.register
 import com.github.imflog.schema.registry.LocalReference
 import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
 import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
@@ -13,7 +14,7 @@ import java.io.File
 class RegisterTaskAction(
     private val client: SchemaRegistryClient,
     private val rootDir: File,
-    private val subjects: List<RegisterSubject>,
+    private val subjects: List<Subject>,
     outputDir: String?
 ) {
 

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
@@ -1,6 +1,5 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
-import com.github.imflog.schema.registry.SchemaType
 import com.github.imflog.schema.registry.Subject
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
@@ -53,7 +52,7 @@ class CompatibilityTaskActionTest {
         folderRule.newFolder("src", "main", "avro", "external")
 
         val subjects =
-            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
+            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", "AVRO"))
         File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
@@ -145,7 +144,7 @@ class CompatibilityTaskActionTest {
             Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
-                SchemaType.AVRO
+                "AVRO"
             )
                 .addReference("Address", "Address", 1)
                 .addReference("Street", "Street", 1)
@@ -243,7 +242,7 @@ class CompatibilityTaskActionTest {
             Subject(
                 "test",
                 "src/main/avro/local/test.avsc",
-                SchemaType.AVRO
+                "AVRO"
             )
                 .addReference("Street", "Street", 1)
                 .addLocalReference("Country", "src/main/avro/local/country.avsc")
@@ -282,7 +281,7 @@ class CompatibilityTaskActionTest {
         folderRule.newFolder("src", "main", "avro", "external")
 
         val subjects =
-            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
+            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", "AVRO"))
         File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
@@ -320,7 +319,7 @@ class CompatibilityTaskActionTest {
             Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
-                SchemaType.AVRO
+                "AVRO"
             )
         )
         File(folderRule.root, "src/main/avro/external/test.avsc").writeText(

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskActionTest.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
 import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
@@ -52,7 +53,7 @@ class CompatibilityTaskActionTest {
         folderRule.newFolder("src", "main", "avro", "external")
 
         val subjects =
-            arrayListOf(CompatibilitySubject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
+            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
         File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
@@ -141,7 +142,7 @@ class CompatibilityTaskActionTest {
         )
 
         val subjects = listOf(
-            CompatibilitySubject(
+            Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
                 SchemaType.AVRO
@@ -239,7 +240,7 @@ class CompatibilityTaskActionTest {
         )
 
         val subjects = listOf(
-            CompatibilitySubject(
+            Subject(
                 "test",
                 "src/main/avro/local/test.avsc",
                 SchemaType.AVRO
@@ -281,7 +282,7 @@ class CompatibilityTaskActionTest {
         folderRule.newFolder("src", "main", "avro", "external")
 
         val subjects =
-            arrayListOf(CompatibilitySubject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
+            arrayListOf(Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO))
         File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
@@ -316,7 +317,7 @@ class CompatibilityTaskActionTest {
         folderRule.newFolder("src", "main", "avro", "external")
 
         val subjects = listOf(
-            CompatibilitySubject(
+            Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
                 SchemaType.AVRO

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -1,6 +1,5 @@
 package com.github.imflog.schema.registry.tasks.register
 
-import com.github.imflog.schema.registry.SchemaType
 import com.github.imflog.schema.registry.Subject
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider
@@ -48,7 +47,7 @@ class RegisterTaskActionTest {
         )
 
         val subjects = listOf(
-            Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO)
+            Subject("test", "src/main/avro/external/test.avsc", "AVRO")
         )
 
         // when
@@ -95,7 +94,7 @@ class RegisterTaskActionTest {
             Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
-                SchemaType.AVRO
+                "AVRO"
             )
         )
 
@@ -178,7 +177,7 @@ class RegisterTaskActionTest {
             Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
-                SchemaType.AVRO
+                "AVRO"
             )
                 .addReference("Address", "Address", 1)
                 .addReference("Street", "Street", 1)
@@ -230,8 +229,8 @@ class RegisterTaskActionTest {
             )
 
         val subjects = listOf(
-            Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO),
-            Subject("test_2", "src/main/avro/external/test_2.avsc", SchemaType.AVRO),
+            Subject("test", "src/main/avro/external/test.avsc", "AVRO"),
+            Subject("test_2", "src/main/avro/external/test_2.avsc", "AVRO"),
         )
 
         // when

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.register
 
 import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
@@ -47,7 +48,7 @@ class RegisterTaskActionTest {
         )
 
         val subjects = listOf(
-            RegisterSubject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO)
+            Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO)
         )
 
         // when
@@ -91,7 +92,7 @@ class RegisterTaskActionTest {
         )
 
         val subjects = listOf(
-            RegisterSubject(
+            Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
                 SchemaType.AVRO
@@ -174,7 +175,7 @@ class RegisterTaskActionTest {
 
 
         val subjects = listOf(
-            RegisterSubject(
+            Subject(
                 "test",
                 "src/main/avro/external/test.avsc",
                 SchemaType.AVRO
@@ -229,8 +230,8 @@ class RegisterTaskActionTest {
             )
 
         val subjects = listOf(
-            RegisterSubject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO),
-            RegisterSubject("test_2", "src/main/avro/external/test_2.avsc", SchemaType.AVRO),
+            Subject("test", "src/main/avro/external/test.avsc", SchemaType.AVRO),
+            Subject("test_2", "src/main/avro/external/test_2.avsc", SchemaType.AVRO),
         )
 
         // when


### PR DESCRIPTION
This change introduces the data class `Subject` replacing the identical data classes `CompatibilitySubject` and `RegisterSubject` and therefore allowing the reuse of subject definitions in the compatibility and register block. 

This change is breaking if `CompatibilitySubject` or `RegisterSubject` were directly used, but I assume most users used the `subject()` DSL in the `register{}` and `compatibility{}` blocks instead, which is not affected by this change. 

@ImFlog please let me know what you think. 

See [issue](https://github.com/ImFlog/schema-registry-plugin/issues/116) 