### PR TITLE
Fix usage documentation

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -12,11 +12,6 @@ jobs:
     strategy:
       matrix:
         kafka_version: [
-          # This version is KO but probably just a container issue.
-          # See https://github.com/testcontainers/testcontainers-java/issues/6423
-          # Disabling it for now
-          # "5.5.1",
-
           "6.2.6",
           "7.2.2",
           "7.3.1"

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -1,6 +1,6 @@
 name: "PR"
 
-on: ["pull_request"]
+on: [ "pull_request" ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -300,3 +300,6 @@ buildscript {
 }
 ```
 
+## Thanks to all the sponsors :pray:
+
+<a href="https://github.com/marktros"><img style="border-radius: 50%;" src="https://github.com/marktros.png" width="60px" alt="Mark Ethan Trostler" /></a>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Download](https://img.shields.io/gradle-plugin-portal/v/com.github.imflog.kafka-schema-registry-gradle-plugin)](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin)
 ![Github Actions](https://github.com/ImFlog/schema-registry-plugin/workflows/Master/badge.svg)
 
 # Schema-registry-plugin
@@ -5,12 +6,15 @@ The aim of this plugin is to adapt the [Confluent schema registry maven plugin](
 
 ## Usage
 
-The plugin requires external dependencies coming from Confluent repositories. You thus need to add this in your build file:
+As the plugin relies on packages developed by confluent you need to add the `https://packages.confluent.io/maven/` repository
+to your `buildscript`:
+
 <div class="tabbed-code-block">
   <details>
     <summary>Groovy</summary>
-    <pre language="groovy">
-      <code>
+      <p>
+
+```groovy
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -22,14 +26,15 @@ buildscript {
 plugins {
   id "com.github.imflog.kafka-schema-registry-gradle-plugin" version "X.X.X"
 }
-      </code>
-    </pre>
-  </details>
+```
 
+    </p>
+  </details>
   <details>
     <summary>Kotlin</summary>
-    <pre language="kotlin">
-<code>
+    <p>
+
+```kotlin
 buildscript {
   repositories {
     gradlePluginPortal()
@@ -41,11 +46,13 @@ buildscript {
 plugins {
   id("com.github.imflog.kafka-schema-registry-gradle-plugin") version "X.X.X"
 }
-</code>
-    </pre>
+```
+
+    </p>
   </details>
 </div>
-You can follow the instructions on the [gradle plugin portal](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin).
+
+Where "X.X.X" is the current version, see [gradle plugin portal](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin) for details.
 
 ## Tasks
 When you install the plugin, four tasks are added under `registry` group:
@@ -240,7 +247,7 @@ schemaRegistry {
 Valid key values are listed here: [org.apache.kafka.common.config.SslConfigs](https://github.com/confluentinc/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/config/SslConfigs.java)
 
 ### Examples
-See the [examples](examples) directory to see the plugin in action !
+Detailed examples can be found in the [examples directory](examples).
 
 ## Version compatibility
 When using the plugin, a default version of the confluent Schema registry is use.
@@ -259,9 +266,9 @@ take a look at [examples/override-confluent-version](examples/override-confluent
 In order to customize the Kafka version to run in integration tests,
 you can specify the ENV VAR KAFKA_VERSION with the version that you want to test upon.
 The library is tested with the following versions:
-* 5.5.1
 * 6.2.6
-* 7.2.1 (by default if no env_var is passed)
+* 7.2.2
+* 7.3.1 (by default if no env_var is passed)
 
 PS: If you are running an ARM computer (like apple M1),
 you can add the `.arm64` suffix to the version to run ARM container and speed up tests.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,46 @@ The aim of this plugin is to adapt the [Confluent schema registry maven plugin](
 
 ## Usage
 
-The plugin requires external dependencies coming from Confluent and Jitpack repositories.
+The plugin requires external dependencies coming from Confluent repositories. You thus need to add this in your build file:
+<div class="tabbed-code-block">
+  <details>
+    <summary>Groovy</summary>
+    <pre language="groovy">
+      <code>
+buildscript {
+    repositories {
+        gradlePluginPortal()
+        maven {
+            url = "https://packages.confluent.io/maven/"
+        }
+    }
+}
+plugins {
+  id "com.github.imflog.kafka-schema-registry-gradle-plugin" version "X.X.X"
+}
+      </code>
+    </pre>
+  </details>
+
+  <details>
+    <summary>Kotlin</summary>
+    <pre language="kotlin">
+<code>
+buildscript {
+  repositories {
+    gradlePluginPortal()
+    maven {
+        url = uri("https://packages.confluent.io/maven/")
+    }
+  }
+}
+plugins {
+  id("com.github.imflog.kafka-schema-registry-gradle-plugin") version "X.X.X"
+}
+</code>
+    </pre>
+  </details>
+</div>
 You can follow the instructions on the [gradle plugin portal](https://plugins.gradle.org/plugin/com.github.imflog.kafka-schema-registry-gradle-plugin).
 
 ## Tasks

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://packages.confluent.io/maven/")
-    maven("https://jitpack.io")
 }
 
 // Dependencies versions

--- a/examples/avro-kts/build.gradle.kts
+++ b/examples/avro-kts/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    id("com.github.imflog.kafka-schema-registry-gradle-plugin")
+}
+
+schemaRegistry {
+    url.set("http://localhost:8081")
+    quiet.set(false)
+    outputDirectory.set("schemas/avro/results/")
+
+    register {
+        subject("company", "schemas/avro/company.avsc", "AVRO")
+                .addLocalReference("Address", "schemas/avro/location-address.avsc")
+        subject("user", "schemas/avro/user.avsc", "AVRO")
+                .addReference("company", "company", -1)
+        subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
+        subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
+    }
+
+    config {
+        subject("company", "FULL_TRANSITIVE")
+        subject("user", "FULL_TRANSITIVE")
+        subject("location-address", "FULL_TRANSITIVE")
+        subject("location-latlong", "FULL_TRANSITIVE")
+    }
+
+    download {
+        subject("company", "schemas/avro/downloaded")
+        subject("user", "schemas/avro/downloaded")
+        subjectPattern("location.*", "schemas/avro/downloaded/location")
+    }
+
+    compatibility {
+        subject("company", "schemas/avro/company_v2.avsc", "AVRO")
+                .addLocalReference("Address", "schemas/avro/location-address.avsc")
+        subject("user", "schemas/avro/user.avsc", "AVRO")
+                .addReference("company", "company", -1)
+        subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
+        subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
+    }
+}

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -1,2 +1,9 @@
 rootProject.name = "examples"
-include("avro", "protobuf", "json", "override-confluent-version", "ssl")
+include(
+    "avro",
+    "avro-kts",
+    "protobuf",
+    "json",
+    "override-confluent-version",
+    "ssl"
+)

--- a/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
@@ -59,20 +59,10 @@ abstract class KafkaTestContainersUtils {
                 )
         }
 
-        @JvmStatic
-        @BeforeAll
-        fun startContainers() {
+        init {
             kafkaContainer.start()
             schemaRegistryContainer.start()
             schemaRegistrySslContainer.start()
-        }
-
-        @JvmStatic
-        @AfterAll
-        fun stopContainers() {
-            schemaRegistryContainer.stop()
-            schemaRegistrySslContainer.stop()
-            kafkaContainer.stop()
         }
     }
 


### PR DESCRIPTION
Should avoid issues like #119 in the future.
I also took the opportunity to:
* update readme documentation how to include the plugin
* Display a chip with the latest version in the Readme
* add an example of usage with a `build.gradle.kts`
* speed up tests by initializing containers only once