### PR TITLE
Fetch latest version for references, if not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,16 @@ if you need information about the registered id.
     }
   }
   ```
+* For remote references, if no version is specified, the latest version of schema is fetched and used from the schema registry:
+```groovy
+schemaRegistry {
+    url = 'http://registry-url:8081'
+    register {
+        subject('avroWithRemoteReferences', '/absolutPath/dependent/path.avsc', "AVRO")
+                .addReference('avroSubject', 'avroSubjectType')
+    }
+}
+```
 
 #### Avro
 Mixing local and remote references is perfectly fine for Avro without specific configurations.

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -15,6 +15,11 @@ data class Subject(
         return this
     }
 
+    fun addReference(name: String, subject:String): Subject {
+        references.add(SchemaReference(name, subject, 0))
+        return this
+    }
+
     fun addLocalReference(name: String, path: String): Subject {
         localReferences.add(LocalReference(name, path))
         return this

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -3,6 +3,7 @@ package com.github.imflog.schema.registry.tasks.compatibility
 import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
 import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
+import com.github.imflog.schema.registry.tasks.support.ReferenceCurrentVersionUtil.updateNonPositiveReferencesToCurrentVersion
 import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
@@ -23,6 +24,7 @@ class CompatibilityTaskAction(
         var errorCount = 0
         for ((subject, path, type, remoteReferences, localReferences) in subjects) {
             logger.debug("Loading schema for subject($subject) from $path.")
+            updateNonPositiveReferencesToCurrentVersion(client, remoteReferences)
             val isCompatible = try {
                 val parsedSchema = SchemaParser
                     .provide(type.toSchemaType(), client, rootDir)

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -5,6 +5,8 @@ import com.github.imflog.schema.registry.LoggingUtils.infoIfNotQuiet
 import com.github.imflog.schema.registry.SchemaType
 import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
+import com.github.imflog.schema.registry.tasks.support.ReferenceCurrentVersionUtil
+import com.github.imflog.schema.registry.tasks.support.ReferenceCurrentVersionUtil.updateNonPositiveReferencesToCurrentVersion
 import com.github.imflog.schema.registry.toSchemaType
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
@@ -27,8 +29,11 @@ class RegisterTaskAction(
     fun run(): Int {
         var errorCount = 0
         writeOutputFileHeader()
-        subjects.forEach { (subject, path, type, references, localReferences) ->
+        subjects.forEach { (subject, path, type, references: List<SchemaReference>, localReferences) ->
             try {
+                updateNonPositiveReferencesToCurrentVersion(
+                    client, references
+                )
                 val schemaId = registerSchema(subject, path, type.toSchemaType(), references, localReferences)
                 writeRegisteredSchemaOutput(subject, path, schemaId)
             } catch (e: Exception) {

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/support/ReferenceCurrentVersionUtil.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/support/ReferenceCurrentVersionUtil.kt
@@ -1,0 +1,38 @@
+package com.github.imflog.schema.registry.tasks.support
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+import org.gradle.api.GradleScriptException
+import org.gradle.api.logging.Logging
+
+object ReferenceCurrentVersionUtil {
+    private val logger = Logging.getLogger(ReferenceCurrentVersionUtil::class.java)
+
+    fun updateNonPositiveReferencesToCurrentVersion(
+        client: SchemaRegistryClient,
+        references: List<SchemaReference>
+    ) {
+        references.forEach {
+            if (it.version <= 0) {
+                it.version = getReferenceCurrentVersion(client, it)
+            }
+        }
+    }
+
+    private fun getReferenceCurrentVersion(
+        client: SchemaRegistryClient,
+        reference: SchemaReference
+    ): Int {
+        logger.debug("Fetching latest remote version for '$reference'")
+
+        val schemas = client.getSchemas(reference.subject, false, true);
+        if (schemas.size == 0) {
+            throw GradleScriptException("Did not find any schemas with the subject '${reference.subject}", Throwable())
+        }
+        if (schemas.size > 1) {
+            throw GradleScriptException("Found more than one schema with the subject prefix '${reference.subject}.", Throwable())
+        }
+
+        return client.getVersion(reference.subject, schemas[0])
+    }
+}

--- a/src/test/kotlin/com/github/imflog/schema/registry/SchemaRegistryPluginTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/SchemaRegistryPluginTest.kt
@@ -3,32 +3,29 @@ package com.github.imflog.schema.registry
 import com.github.imflog.schema.registry.tasks.download.DownloadTask
 import org.assertj.core.api.Assertions
 import org.gradle.api.Project
-import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
 class SchemaRegistryPluginTest {
     lateinit var project: Project
-    lateinit var folderRule: TemporaryFolder
+    @TempDir
+    lateinit var folderRule: Path
     lateinit var buildFile: File
 
     private val subject = "test-subject"
 
     @BeforeEach
     fun init() {
-        folderRule = TemporaryFolder()
         project = ProjectBuilder.builder().build()
         project.pluginManager.apply(SchemaRegistryPlugin::class.java)
-    }
-
-    @AfterEach
-    fun tearDown() {
-        folderRule.delete()
+        Files.createFile(folderRule.resolve("build.gradle"))
     }
 
     @Test
@@ -41,13 +38,12 @@ class SchemaRegistryPluginTest {
 
     @Test
     fun `plugin should fail with wrong url extension configuration`() {
-        folderRule.create()
-        buildFile = folderRule.newFile("build.gradle")
+        buildFile = File(folderRule.toFile(), "build.gradle")
         buildFile.writeText(
             """
             plugins {
                 id 'java'
-                id 'com.github.imflog.kafka-schema-registry-gradle-plugin'
+                id 'com.indeed.indeed-modified-schema-registry-plugin'
             }
 
             schemaRegistry {
@@ -61,7 +57,7 @@ class SchemaRegistryPluginTest {
         try {
             GradleRunner.create()
                 .withGradleVersion("6.7.1")
-                .withProjectDir(folderRule.root)
+                .withProjectDir(folderRule.toFile())
                 .withArguments(DownloadTask.TASK_NAME)
                 .withPluginClasspath()
                 .withDebug(true)
@@ -74,13 +70,12 @@ class SchemaRegistryPluginTest {
 
     @Test
     fun `plugin should fail with wrong credentials extension configuration`() {
-        folderRule.create()
-        buildFile = folderRule.newFile("build.gradle")
+        buildFile = File(folderRule.toFile(), "build.gradle")
         buildFile.writeText(
             """
             plugins {
                 id 'java'
-                id 'com.github.imflog.kafka-schema-registry-gradle-plugin'
+                id 'com.indeed.indeed-modified-schema-registry-plugin'
             }
 
             schemaRegistry {
@@ -99,7 +94,7 @@ class SchemaRegistryPluginTest {
         try {
             GradleRunner.create()
                 .withGradleVersion("6.7.1")
-                .withProjectDir(folderRule.root)
+                .withProjectDir(folderRule.toFile())
                 .withArguments(DownloadTask.TASK_NAME)
                 .withPluginClasspath()
                 .withDebug(true)
@@ -112,13 +107,12 @@ class SchemaRegistryPluginTest {
 
     @Test
     fun `plugin should only parse nested extensions`() {
-        folderRule.create()
-        buildFile = folderRule.newFile("build.gradle")
+        buildFile = File(folderRule.toFile(), "build.gradle")
         buildFile.writeText(
             """
             plugins {
                 id 'java'
-                id 'com.github.imflog.kafka-schema-registry-gradle-plugin'
+                id 'com.indeed.indeed-modified-schema-registry-plugin'
             }
 
             // This should not be taken into account
@@ -136,7 +130,7 @@ class SchemaRegistryPluginTest {
         try {
             GradleRunner.create()
                 .withGradleVersion("6.7.1")
-                .withProjectDir(folderRule.root)
+                .withProjectDir(folderRule.toFile())
                 .withArguments(DownloadTask.TASK_NAME)
                 .withPluginClasspath()
                 .withDebug(true)

--- a/src/test/kotlin/com/github/imflog/schema/registry/parser/AvroSchemaParserTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/parser/AvroSchemaParserTest.kt
@@ -3,21 +3,18 @@ package com.github.imflog.schema.registry.parser
 import com.github.imflog.schema.registry.LocalReference
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
 import org.assertj.core.api.Assertions
-import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.json.JSONObject
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AvroSchemaParserTest {
 
     private val schemaRegistryClient = MockSchemaRegistryClient()
-    private val folderRule: TemporaryFolder = TemporaryFolder().apply { create() }
-    private val parser = AvroSchemaParser(
-        schemaRegistryClient,
-        folderRule.root
-    )
+    @TempDir
+    lateinit var folderRule: Path
 
     companion object {
         private const val ADDRESS_REFERENCE_NAME = "Address"
@@ -39,14 +36,10 @@ class AvroSchemaParserTest {
         }"""
     }
 
-    @AfterAll
-    fun tearDown() {
-        folderRule.delete()
-    }
-
     @Test
     fun `Should format local references correctly`() {
         // Given
+        val parser = AvroSchemaParser(schemaRegistryClient, folderRule.toFile())
         val aLocalReference = givenALocalReference()
 
         // When
@@ -61,7 +54,7 @@ class AvroSchemaParserTest {
     }
 
     private fun givenALocalReference(): LocalReference {
-        val addressLocalFile = folderRule.root.resolve("Address.avsc")
+        val addressLocalFile = folderRule.resolve("Address.avsc").toFile()
         addressLocalFile.writeText(ADDRESS_SCHEMA)
         return LocalReference(ADDRESS_REFERENCE_NAME, addressLocalFile.path)
     }

--- a/src/test/kotlin/com/github/imflog/schema/registry/parser/JsonSchemaParserTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/parser/JsonSchemaParserTest.kt
@@ -3,21 +3,18 @@ package com.github.imflog.schema.registry.parser
 import com.github.imflog.schema.registry.LocalReference
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
 import org.assertj.core.api.Assertions
-import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.json.JSONObject
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class JsonSchemaParserTest {
 
     private val schemaRegistryClient = MockSchemaRegistryClient()
-    private val folderRule: TemporaryFolder = TemporaryFolder().apply { create() }
-    private val parser = JsonSchemaParser(
-        schemaRegistryClient,
-        folderRule.root
-    )
+    @TempDir
+    lateinit var folderRule: Path
 
     companion object {
         private const val ADDRESS_REFERENCE_NAME = "Address"
@@ -43,14 +40,10 @@ class JsonSchemaParserTest {
         }"""
     }
 
-    @AfterAll
-    fun tearDown() {
-        folderRule.delete()
-    }
-
     @Test
     fun `Should format local references correctly`() {
         // Given
+        val parser = JsonSchemaParser(schemaRegistryClient, folderRule.toFile())
         val aLocalReference = givenALocalReference()
 
         // When
@@ -65,7 +58,7 @@ class JsonSchemaParserTest {
     }
 
     private fun givenALocalReference(): LocalReference {
-        val addressLocalFile = folderRule.root.resolve("Address.json")
+        val addressLocalFile = folderRule.resolve("Address.json").toFile()
         addressLocalFile.writeText(ADDRESS_SCHEMA)
         return LocalReference(ADDRESS_REFERENCE_NAME, addressLocalFile.path)
     }

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
@@ -6,25 +6,14 @@ import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider
 import org.assertj.core.api.Assertions
-import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Path
 
 class DownloadTaskActionTest {
-    lateinit var folderRule: TemporaryFolder
-
-    @BeforeEach
-    fun setUp() {
-        folderRule = TemporaryFolder()
-        folderRule.create()
-    }
-
-    @AfterEach
-    fun tearDown() {
-        folderRule.delete()
-    }
+    @TempDir
+    lateinit var folderRule: Path
 
     @Test
     fun `Should download schemas`() {
@@ -63,12 +52,13 @@ class DownloadTaskActionTest {
             ).get()
         )
 
-        folderRule.newFolder("src", "main", "avro", "external")
+        folderRule.resolve("src/main/avro/external").toFile().mkdir()
+        val folderRoot = folderRule.toFile()
 
         // when
         val errorCount = DownloadTaskAction(
             registryClient,
-            folderRule.root,
+            folderRoot,
             arrayListOf(
                 DownloadSubject(testSubject, outputDir),
                 DownloadSubject(fooSubject, outputDir)
@@ -77,11 +67,11 @@ class DownloadTaskActionTest {
 
         // then
         Assertions.assertThat(errorCount).isEqualTo(0)
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc")).isNotNull
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc")).isNotNull
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc").readText())
             .containsIgnoringCase("test")
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/foo.avsc")).isNotNull
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/foo.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/foo.avsc")).isNotNull
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/foo.avsc").readText())
             .containsIgnoringCase("foo")
     }
 
@@ -135,12 +125,13 @@ class DownloadTaskActionTest {
             ).get()
         )
 
-        folderRule.newFolder("src", "main", "avro", "external")
+        folderRule.resolve("src/main/avro/external").toFile().mkdir()
+        val folderRoot = folderRule.toFile()
 
         // when
         val errorCount = DownloadTaskAction(
             registryClient,
-            folderRule.root,
+            folderRoot,
             arrayListOf(
                 DownloadSubject("te.*", outputDir, null, true)
             ),
@@ -148,13 +139,13 @@ class DownloadTaskActionTest {
 
         // then
         Assertions.assertThat(errorCount).isEqualTo(0)
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc")).exists()
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc")).exists()
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc").readText())
             .containsIgnoringCase("test")
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/tea.avsc")).exists()
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/tea.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/tea.avsc")).exists()
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/tea.avsc").readText())
             .containsIgnoringCase("tea")
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/foo.avsc")).doesNotExist()
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/foo.avsc")).doesNotExist()
     }
 
     @Test
@@ -183,12 +174,13 @@ class DownloadTaskActionTest {
             ).get()
         )
 
-        folderRule.newFolder("src", "main", "avro", "external")
+        folderRule.resolve("src/main/avro/external").toFile().mkdir()
+        val folderRoot = folderRule.toFile()
 
         // when
         val errorCount = DownloadTaskAction(
             registryClient,
-            folderRule.root,
+            folderRoot,
             arrayListOf(DownloadSubject(subject, outputDir)),
         ).run()
 
@@ -214,12 +206,13 @@ class DownloadTaskActionTest {
             ).get()
         )
 
-        folderRule.newFolder("src", "main", "avro", "external")
+        folderRule.resolve("src/main/avro/external").toFile().mkdir()
+        val folderRoot = folderRule.toFile()
 
         // when
         val errorCount = DownloadTaskAction(
             registryClient,
-            folderRule.root,
+            folderRoot,
             arrayListOf(
                 DownloadSubject(invalidSubjectPattern, outputDir, null, true),
                 DownloadSubject("test", outputDir)
@@ -228,8 +221,8 @@ class DownloadTaskActionTest {
 
         // then
         Assertions.assertThat(errorCount).isEqualTo(0)
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc")).exists()
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc")).exists()
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc").readText())
             .containsIgnoringCase("test")
     }
 
@@ -267,12 +260,13 @@ class DownloadTaskActionTest {
         )
         Assertions.assertThat(v1Id).isNotEqualTo(v2Id)
 
-        folderRule.newFolder("src", "main", "avro", "external")
+        folderRule.resolve("src/main/avro/external").toFile().mkdir()
+        val folderRoot = folderRule.toFile()
 
         // When
         val errorCount = DownloadTaskAction(
             registryClient,
-            folderRule.root,
+            folderRoot,
             arrayListOf(
                 DownloadSubject("test", outputDir, v1Id)
             ),
@@ -280,10 +274,10 @@ class DownloadTaskActionTest {
 
         // Then
         Assertions.assertThat(errorCount).isEqualTo(0)
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc")).isNotNull
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc")).isNotNull
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc").readText())
             .containsIgnoringCase("test")
-        Assertions.assertThat(File(folderRule.root, "src/main/avro/external/test.avsc").readText())
+        Assertions.assertThat(File(folderRoot, "src/main/avro/external/test.avsc").readText())
             .doesNotContain("desc")
     }
 }

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -8,24 +8,21 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider
 import org.assertj.core.api.Assertions
-import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 
 class RegisterTaskActionTest {
-    lateinit var folderRule: TemporaryFolder
+    @TempDir
+    lateinit var folderRule: Path
 
     @BeforeEach
-    fun setUp() {
-        folderRule = TemporaryFolder()
-        folderRule.create()
-    }
-
-    @AfterEach
-    fun tearDown() {
-        folderRule.delete()
+    fun init() {
+        Files.createDirectories(folderRule.resolve("src/main/avro/external/"))
+        Files.createFile(folderRule.resolve("src/main/avro/external/test.avsc"))
     }
 
     @Test
@@ -33,8 +30,7 @@ class RegisterTaskActionTest {
         // given
         val registryClient =
             MockSchemaRegistryClient(listOf(AvroSchemaProvider(), JsonSchemaProvider(), ProtobufSchemaProvider()))
-        folderRule.newFolder("src", "main", "avro", "external")
-        File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
+        File(folderRule.toFile(), "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
              "name": "test",
@@ -53,7 +49,7 @@ class RegisterTaskActionTest {
         // when
         val errorCount = RegisterTaskAction(
             registryClient,
-            folderRule.root,
+            folderRule.toFile(),
             subjects,
             null
         ).run()
@@ -77,8 +73,7 @@ class RegisterTaskActionTest {
             ).get()
         )
 
-        folderRule.newFolder("src", "main", "avro", "external")
-        File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
+        File(folderRule.toFile(), "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
              "name": "test",
@@ -101,7 +96,7 @@ class RegisterTaskActionTest {
         // when
         val errorCount = RegisterTaskAction(
             registryClient,
-            folderRule.root,
+            folderRule.toFile(),
             subjects,
             null
         ).run()
@@ -125,8 +120,6 @@ class RegisterTaskActionTest {
                 listOf()
             ).get()
         )
-
-        folderRule.newFolder("src", "main", "avro", "external")
 
         // Register dependency
         registryClient.register(
@@ -160,7 +153,7 @@ class RegisterTaskActionTest {
             ).get()
         )
 
-        File(folderRule.root, "src/main/avro/external/test.avsc").writeText(
+        File(folderRule.toFile(), "src/main/avro/external/test.avsc").writeText(
             """
             {"type": "record",
              "name": "test",
@@ -186,7 +179,89 @@ class RegisterTaskActionTest {
         // when
         val errorCount = RegisterTaskAction(
             registryClient,
-            folderRule.root,
+            folderRule.toFile(),
+            subjects,
+            null
+        ).run()
+
+        // then
+        Assertions.assertThat(errorCount).isEqualTo(0)
+        Assertions.assertThat(registryClient.getLatestSchemaMetadata("test")).isNotNull
+    }
+
+    @Test
+    fun `Should register schema with latest remote version of references`() {
+        // given
+        val registryClient =
+            MockSchemaRegistryClient(listOf(AvroSchemaProvider(), JsonSchemaProvider(), ProtobufSchemaProvider()))
+        registryClient.register(
+            "test",
+            registryClient.parseSchema(
+                AvroSchema.TYPE,
+                """{"type": "record", "name": "test", "fields": [{ "name": "name", "type": "string" }]}""",
+                listOf()
+            ).get()
+        )
+
+        // Register dependency
+        registryClient.register(
+            "Street",
+            registryClient.parseSchema(
+                AvroSchema.TYPE,
+                """{
+                    "type": "record",
+                    "name": "Street",
+                    "fields": [
+                        {"name": "street", "type": "string" }
+                    ]
+                }""",
+                listOf()
+            ).get()
+        )
+
+        registryClient.register(
+            "Address",
+            registryClient.parseSchema(
+                AvroSchema.TYPE,
+                """{
+                    "type": "record",
+                    "name": "Address",
+                    "fields": [
+                        {"name": "city", "type": "string" },
+                        {"name": "street", "type": "Street" }
+                    ]
+                }""",
+                listOf(SchemaReference("Street", "Street", 1))
+            ).get()
+        )
+
+        File(folderRule.toFile(), "src/main/avro/external/test.avsc").writeText(
+            """
+            {"type": "record",
+             "name": "test",
+             "fields": [
+                {"name": "name", "type": "string" },
+                {"name": "address", "type": "Address"}
+             ]
+            }
+        """.trimIndent()
+        )
+
+
+        val subjects = listOf(
+            Subject(
+                "test",
+                "src/main/avro/external/test.avsc",
+                "AVRO"
+            )
+                .addReference("Address", "Address")
+                .addReference("Street", "Street")
+        )
+
+        // when
+        val errorCount = RegisterTaskAction(
+            registryClient,
+            folderRule.toFile(),
             subjects,
             null
         ).run()
@@ -201,9 +276,8 @@ class RegisterTaskActionTest {
         // given
         val registryClient =
             MockSchemaRegistryClient(listOf(AvroSchemaProvider(), JsonSchemaProvider(), ProtobufSchemaProvider()))
-        folderRule.newFolder("src", "main", "avro", "external")
-        val resultFolder = folderRule.newFolder("results", "avro")
-        File(folderRule.root, "src/main/avro/external/test.avsc")
+        val resultFolder = Files.createDirectories(folderRule.resolve("results/avro")).toFile()
+        File(folderRule.toFile(), "src/main/avro/external/test.avsc")
             .writeText(
                 """
                 {"type": "record",
@@ -215,7 +289,7 @@ class RegisterTaskActionTest {
                 }
             """
             )
-        File(folderRule.root, "src/main/avro/external/test_2.avsc")
+        File(folderRule.toFile(), "src/main/avro/external/test_2.avsc")
             .writeText(
                 """
                 {"type": "record",
@@ -236,7 +310,7 @@ class RegisterTaskActionTest {
         // when
         RegisterTaskAction(
             registryClient,
-            folderRule.root,
+            folderRule.toFile(),
             subjects,
             resultFolder.path
         ).run()


### PR DESCRIPTION
As a developer using Confluent's schema registry, I want to always have a remote reference pointing at the latest remote version. There are cases where the version is unknown, or where it drifts between environments. By simply using the latest version, a large burden of managing versions across environments in our build file is lifted.

As a developer using this plugin, I don't want to necessarily specify the remote schema version when specifying my references. I need a method of communicating this in my definition(s).

A new method has been added to the `Subject` class, `addReference(name: String, subject:String)`. When a reference is not specified with a verion, the compatibility and register tasks will fetch the latest version from the configured schema registry.