### PR TITLE
Add ability to download schema references

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,15 @@ schemaRegistry {
 Here is the list of all the signatures for the `subject` extension:
 
 * `subject(inputSubject: String, outputPath: String)`
+* `subject(inputSubject: String, outputPath: String, downloadReferences: Boolean)`
 * `subject(inputSubject: String, outputPath: String, outputFileName: String)`
+* `subject(inputSubject: String, outputPath: String, outputFileName: String, downloadReferences: Boolean)`
 * `subject(inputSubject: String, outputPath: String, version: Int)`
+* `subject(inputSubject: String, outputPath: String, version: Int, downloadReferences: Boolean)`
 * `subject(inputSubject: String, outputPath: String, version: Int, outputFileName: String)`
+* `subject(inputSubject: String, outputPath: String, version: Int, outputFileName: String, downloadReferences: Boolean)`
 * `subjectPattern(inputPattern: String, outputPath: String)`
+* `subjectPattern(inputPattern: String, outputPath: String, downloadReferences: Boolean)`
 
 You can configure the metadata extension in order to download the schemas metadata in json files.
 It will be saved in files named like the schema file but suffixed by `-metadata.json` in the outputPath you specify

--- a/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
@@ -4,8 +4,10 @@ import com.github.imflog.schema.registry.toSchemaType
 import com.github.imflog.schema.registry.utils.KafkaTestContainersUtils
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import io.confluent.kafka.schemaregistry.json.JsonSchema
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
+import org.apache.avro.Schema
 import org.assertj.core.api.Assertions
 import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testkit.runner.BuildResult
@@ -326,6 +328,88 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
         val metadataFile = "$subjectName-metadata.json"
         Assertions.assertThat(File(folderRule.root, "src/main/avro/test/$schemaFile")).exists()
         Assertions.assertThat(File(folderRule.root, "src/main/avro/metadata/$metadataFile")).exists()
+        Assertions.assertThat(result?.task(":downloadSchemasTask")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `Should download schema with references in specific directory`() {
+        // Given
+        val subjectName = "reference_test"
+        val recordName = "UserReference"
+        val subjectNameLib = "reference_test_lib"
+        val recordNameLib = "UserReferenceLib"
+
+        client.register(
+            subjectNameLib,
+            AvroSchema(
+                """{
+                    "type": "record",
+                    "name": "${recordNameLib}",
+                    "fields": [
+                        { "name": "name", "type": "string" }
+                    ]
+                }"""
+            )
+        )
+
+        client.register(
+            subjectName,
+            AvroSchema(
+                """{
+                    "type": "record",
+                    "name": "${recordName}",
+                    "fields": [
+                        { "name": "name", "type": "string" }
+                    ]
+                }""",
+                listOf(
+                    SchemaReference(recordNameLib, subjectNameLib, 1)
+                ),
+                mapOf(),
+                null
+            )
+        )
+
+        buildFile = folderRule.newFile("build.gradle")
+        buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id 'com.github.imflog.kafka-schema-registry-gradle-plugin'
+            }
+
+            import com.github.imflog.schema.registry.tasks.download.MetadataExtension
+            schemaRegistry {
+                url = '$schemaRegistryEndpoint'
+                download {
+                    metadata = new MetadataExtension(true, '${folderRule.root.absolutePath}/src/main/avro/metadata')
+
+                    subject('$subjectName', '${folderRule.root.absolutePath}/src/main/avro/test', true)
+                }
+            }
+        """
+        )
+
+        // When
+        val result: BuildResult? = GradleRunner.create()
+            .withGradleVersion("6.7.1")
+            .withProjectDir(folderRule.root)
+            .withArguments(DownloadTask.TASK_NAME)
+            .withPluginClasspath()
+            .withDebug(true)
+            .build()
+
+        // Then
+        val schemaFile = "$subjectName.avsc"
+        val metadataFile = "$subjectName-metadata.json"
+        Assertions.assertThat(File(folderRule.root, "src/main/avro/test/$schemaFile")).exists()
+        Assertions.assertThat(File(folderRule.root, "src/main/avro/metadata/$metadataFile")).exists()
+
+        val libSchemaFile = "$subjectNameLib.avsc"
+        val libMetadataFile = "$subjectNameLib-metadata.json"
+        Assertions.assertThat(File(folderRule.root, "src/main/avro/test/$libSchemaFile")).exists()
+        Assertions.assertThat(File(folderRule.root, "src/main/avro/metadata/$libMetadataFile")).exists()
+
         Assertions.assertThat(result?.task(":downloadSchemasTask")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
     }
 

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadSubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadSubjectExtension.kt
@@ -22,20 +22,40 @@ open class DownloadSubjectExtension(objects: ObjectFactory) {
         subjects.add(DownloadSubject(inputSubject, outputPath))
     }
 
+    fun subject(inputSubject: String, outputPath: String, downloadReferences: Boolean) {
+        subjects.add(DownloadSubject(inputSubject, outputPath, downloadReferences = downloadReferences))
+    }
+
     fun subject(inputSubject: String, outputPath: String, outputFileName: String) {
         subjects.add(DownloadSubject(inputSubject, outputPath, outputFileName = outputFileName))
+    }
+
+    fun subject(inputSubject: String, outputPath: String, outputFileName: String, downloadReferences: Boolean) {
+        subjects.add(DownloadSubject(inputSubject, outputPath, outputFileName = outputFileName, downloadReferences = downloadReferences))
     }
 
     fun subject(inputSubject: String, outputPath: String, version: Int) {
         subjects.add(DownloadSubject(inputSubject, outputPath, version))
     }
 
+    fun subject(inputSubject: String, outputPath: String, version: Int, downloadReferences: Boolean) {
+        subjects.add(DownloadSubject(inputSubject, outputPath, version, downloadReferences = downloadReferences))
+    }
+
     fun subject(inputSubject: String, outputPath: String, version: Int, outputFileName: String) {
         subjects.add(DownloadSubject(inputSubject, outputPath, version, outputFileName = outputFileName))
     }
 
+    fun subject(inputSubject: String, outputPath: String, version: Int, outputFileName: String, downloadReferences: Boolean) {
+        subjects.add(DownloadSubject(inputSubject, outputPath, version, outputFileName = outputFileName, downloadReferences = downloadReferences))
+    }
+
     fun subjectPattern(inputPattern: String, outputPath: String) {
         subjects.add(DownloadSubject(inputPattern, outputPath, null, true))
+    }
+
+    fun subjectPattern(inputPattern: String, outputPath: String, downloadReferences: Boolean) {
+        subjects.add(DownloadSubject(inputPattern, outputPath, null, true, downloadReferences = downloadReferences))
     }
 }
 

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadSubjectExtension.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadSubjectExtension.kt
@@ -44,7 +44,8 @@ data class DownloadSubject(
     val outputPath: String,
     val version: Int? = null,
     val regex: Boolean = false,
-    val outputFileName: String? = null
+    val outputFileName: String? = null,
+    val downloadReferences: Boolean = false
 )
 
 data class MetadataExtension(


### PR DESCRIPTION
Added ability to download schema references.

A new configuration `downloadReferences: Boolean` was added to `DownloadSchema`.

When set to true, and the schema has references, the referenced schemas are also downloaded. This will allow POJO generation to succeed from schema with references.