### PR TITLE
Adding subject metadata and ruleset capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The addLocalReference calls can be chained.
 
 You can also provide `setNormalized(true)` to normalize the schema. Here is a link for more information: [Schema Normalization](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#schema-normalization)
 
-For some schema registries like the one offered by `conluend-cloud`, you can add `metadata` and `rulesets` to a subject.
+For some schema registries like the one offered by `confluent-cloud`, you can add `metadata` and `rulesets` to a subject.
 Here are some links for more information: 
 * [Schema Registry Rules](https://docs.confluent.io/platform/7.5/schema-registry/fundamentals/data-contracts.html#rules)
 * [Schema Registry Metadata](https://docs.confluent.io/platform/7.5/schema-registry/fundamentals/data-contracts.html#metadata-properties)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Here is the list of all the signatures for the `subject` extension:
 You can configure the metadata extension in order to download the schemas metadata in json files.
 It will be saved in files named like the schema file but suffixed by `-metadata.json` in the outputPath you specify
 and defaults to the same output directory as your schemas.
+The metadata extension will also download optional `metadata` and `rulesets` if your schema-registry supports this.  
 
 NB:
 
@@ -204,6 +205,8 @@ schemaRegistry {
                 .addReference('avroSubjectLatestVersionExplicit', 'avroSubjectLatestVersionExplicitType', -1)
         subject('protoWithReferences', 'dependent/path.proto', "PROTOBUF").addReference('protoSubject', 'protoSubjectType', 1)
         subject('jsonWithReferences', 'dependent/path.json', "JSON").addReference('jsonSubject', 'jsonSubjectType', 1)
+                .setMetadata('/absolutPath/dependent/metadata.json').setRuleSet('/absolutPath/dependent/ruleset.json')
+                .setNormalized(true)
     }
 }
 ```
@@ -220,6 +223,13 @@ If you have local references to add before calling the register,
 you can call the `addLocalReference("name", "/a/path")`,
 this will add a reference from a local file and inline it in the schema registry call.
 The addLocalReference calls can be chained.
+
+You can also provide `setNormalized(true)` to normalize the schema. Here is a link for more information: [Schema Normalization](https://docs.confluent.io/platform/current/schema-registry/fundamentals/serdes-develop/index.html#schema-normalization)
+
+For some schema registries like the one offered by `conluend-cloud`, you can add `metadata` and `rulesets` to a subject.
+Here are some links for more information: 
+* [Schema Registry Rules](https://docs.confluent.io/platform/7.5/schema-registry/fundamentals/data-contracts.html#rules)
+* [Schema Registry Metadata](https://docs.confluent.io/platform/7.5/schema-registry/fundamentals/data-contracts.html#metadata-properties)
 
 Notes:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.imflog"
-version = "1.13.4-SNAPSHOT"
+version = "1.13.1-SNAPSHOT"
 
 
 plugins {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "com.github.imflog"
-version = "1.13.1-SNAPSHOT"
+version = "1.13.4-SNAPSHOT"
 
 
 plugins {
@@ -19,7 +19,6 @@ repositories {
 // Dependencies versions
 val confluentVersion = "7.5.3"
 val avroVersion = "1.11.2"
-val jsonVersion = "2.8.9"
 dependencies {
     shadow(gradleApi())
     implementation(platform("io.confluent:kafka-schema-registry-parent:$confluentVersion"))
@@ -30,7 +29,6 @@ dependencies {
     implementation("io.confluent", "kafka-protobuf-provider")
     // Our custom avro version. See https://github.com/ImFlog/avro
     implementation("com.github.ImFlog.avro", "avro", avroVersion)
-    implementation("com.google.code.gson","gson",jsonVersion)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
 // Dependencies versions
 val confluentVersion = "7.5.3"
 val avroVersion = "1.11.2"
+val jsonVersion = "2.8.9"
 dependencies {
     shadow(gradleApi())
     implementation(platform("io.confluent:kafka-schema-registry-parent:$confluentVersion"))
@@ -29,6 +30,7 @@ dependencies {
     implementation("io.confluent", "kafka-protobuf-provider")
     // Our custom avro version. See https://github.com/ImFlog/avro
     implementation("com.github.ImFlog.avro", "avro", avroVersion)
+    implementation("com.google.code.gson","gson",jsonVersion)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/examples/avro-kts/build.gradle.kts
+++ b/examples/avro-kts/build.gradle.kts
@@ -17,6 +17,10 @@ schemaRegistry {
                 .addReference("company", "company", -1)
         subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
         subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
+        subject("my-record","schemas/avro/my-record.avsc", "AVRO")
+            .setMetadata("examples/extra/metadata.json")
+            .setRuleSet("examples/extra/ruleSet.json")
+            .setNormalized(true)
     }
 
     config {

--- a/examples/avro-kts/build.gradle.kts
+++ b/examples/avro-kts/build.gradle.kts
@@ -18,8 +18,8 @@ schemaRegistry {
         subject("location-address", "schemas/avro/location-address.avsc", "AVRO")
         subject("location-latlong", "schemas/avro/location-latlong.avsc", "AVRO")
         subject("my-record","schemas/avro/my-record.avsc", "AVRO")
-            .setMetadata("examples/extra/metadata.json")
-            .setRuleSet("examples/extra/ruleSet.json")
+            .setMetadata("extra/metadata.json")
+            .setRuleSet("extra/ruleSet.json")
             .setNormalized(true)
     }
 

--- a/examples/avro/build.gradle
+++ b/examples/avro/build.gradle
@@ -20,6 +20,10 @@ schemaRegistry {
                 .addReference('company', 'company', -1)
         subject(locationAddressSubject)
         subject(locationCoordSubject)
+        subject("my-record","schemas/avro/my-record.avsc", "AVRO")
+                .setMetadata("examples/extra/metadata.json")
+                .setRuleSet("examples/extra/ruleSet.json")
+                .setNormalized(true)
     }
 
     config {

--- a/examples/avro/build.gradle
+++ b/examples/avro/build.gradle
@@ -21,8 +21,8 @@ schemaRegistry {
         subject(locationAddressSubject)
         subject(locationCoordSubject)
         subject("my-record","schemas/avro/my-record.avsc", "AVRO")
-                .setMetadata("examples/extra/metadata.json")
-                .setRuleSet("examples/extra/ruleSet.json")
+                .setMetadata("extra/metadata.json")
+                .setRuleSet("extra/ruleSet.json")
                 .setNormalized(true)
     }
 
@@ -37,6 +37,7 @@ schemaRegistry {
         metadata = new MetadataExtension(true)
 //        subject('company', 'schemas/avro/downloaded') // is retrieved via reference from the user subject
         subject('user', 'schemas/avro/downloaded', true)
+        subject('my-record', 'schemas/avro/downloaded', true)
         subjectPattern('location.*', 'schemas/avro/downloaded/location')
     }
 

--- a/examples/extra/metadata.json
+++ b/examples/extra/metadata.json
@@ -1,0 +1,9 @@
+{
+  "tags": {
+    "**.ssn": [ "PII" ]
+  },
+  "properties": {
+    "owner": "Bob Jones",
+    "email": "bob@acme.com"
+  }
+}

--- a/examples/extra/ruleSet.json
+++ b/examples/extra/ruleSet.json
@@ -1,0 +1,19 @@
+{
+  "domainRules": [
+    {
+      "name": "encryptPII",
+      "kind": "TRANSFORM",
+      "type": "ENCRYPT",
+      "mode": "WRITEREAD",
+      "tags": [
+        "PII"
+      ],
+      "params": {
+        "encrypt.kek.name": "kafka-csfle",
+        "encrypt.kms.key.id": "projects/gcp-project/locations/europe-west6/keyRings/gcp-keyring/cryptoKeys/kafka-csfle",
+        "encrypt.kms.type": "gcp-kms"
+      },
+      "onFailure": "ERROR,NONE"
+    }
+  ]
+}

--- a/examples/json/build.gradle
+++ b/examples/json/build.gradle
@@ -21,6 +21,10 @@ schemaRegistry {
             .addReference('company', 'company', -1)
         subject(locationAddressSubject)
         subject(locationCoordSubject)
+        subject('my-record','schemas/json/my-record.json','JSON')
+                .setMetadata('examples/extra/metadata.json')
+                .setRuleSet('examples/extra/ruleSet.json')
+                .setNormalized(true)
     }
 
     config {

--- a/examples/json/build.gradle
+++ b/examples/json/build.gradle
@@ -22,8 +22,8 @@ schemaRegistry {
         subject(locationAddressSubject)
         subject(locationCoordSubject)
         subject('my-record','schemas/json/my-record.json','JSON')
-                .setMetadata('examples/extra/metadata.json')
-                .setRuleSet('examples/extra/ruleSet.json')
+                .setMetadata('extra/metadata.json')
+                .setRuleSet('extra/ruleSet.json')
                 .setNormalized(true)
     }
 

--- a/examples/protobuf/build.gradle
+++ b/examples/protobuf/build.gradle
@@ -20,6 +20,10 @@ schemaRegistry {
                 .addReference('company', 'company', 1)
         subject(locationAddressSubject)
         subject(locationCoordSubject)
+        subject('my-record','schemas/protobuf/com/example/my-record.proto','PROTOBUF')
+            .setMetadata('examples/extra/metadata.json')
+            .setRuleSet('examples/extra/ruleSet.json')
+            .setNormalized(true)
     }
 
     config {

--- a/examples/protobuf/build.gradle
+++ b/examples/protobuf/build.gradle
@@ -21,8 +21,8 @@ schemaRegistry {
         subject(locationAddressSubject)
         subject(locationCoordSubject)
         subject('my-record','schemas/protobuf/com/example/my-record.proto','PROTOBUF')
-            .setMetadata('examples/extra/metadata.json')
-            .setRuleSet('examples/extra/ruleSet.json')
+            .setMetadata('extra/metadata.json')
+            .setRuleSet('extra/ruleSet.json')
             .setNormalized(true)
     }
 

--- a/examples/schemas/avro/my-record.avsc
+++ b/examples/schemas/avro/my-record.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "com.github.imflog",
+  "type": "record",
+  "name": "MyRecord",
+  "fields":[{
+    "name":"ssn",
+    "type":"string",
+    "confluent:tags": [ "PII" ]
+  }]
+}

--- a/examples/schemas/json/my-record.json
+++ b/examples/schemas/json/my-record.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "MyRecord",
+  "type": "object",
+  "properties": {
+    "ssn": {
+      "type": "string",
+      "confluent:tags": [ "PII" ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/examples/schemas/protobuf/com/example/my-record.proto
+++ b/examples/schemas/protobuf/com/example/my-record.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+import "confluent/meta.proto";
+
+
+message MyRecord {
+  string ssn = 1 [
+    (confluent.field_meta).tags = "PII"
+  ];
+}

--- a/src/integration/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskIT.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskIT.kt
@@ -260,9 +260,9 @@ class CompatibilityTaskIT : KafkaTestContainersUtils() {
             schemaRegistry {
                 url = '$schemaRegistryEndpoint'
                 compatibility {
-                    subject('$playerSubject', '${playerFile.absolutePath}', '${type.name}')
+                    subject('${playerSubject.inputSubject}', '${playerFile.absolutePath}', '${type.name}')
                         .addLocalReference('$userSubject', '$userPath')
-                        .addReference('$addressReferenceName', '$addressSubject', 1)
+                        .addReference('$addressReferenceName', '${addressSubject.inputSubject}', 1)
                 }
             }
         """

--- a/src/integration/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskIT.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskIT.kt
@@ -1,6 +1,7 @@
 package com.github.imflog.schema.registry.tasks.compatibility
 
 import com.github.imflog.schema.registry.SchemaType
+import com.github.imflog.schema.registry.Subject
 import com.github.imflog.schema.registry.parser.SchemaParser
 import com.github.imflog.schema.registry.utils.KafkaTestContainersUtils
 import io.confluent.kafka.schemaregistry.ParsedSchema
@@ -231,20 +232,17 @@ class CompatibilityTaskIT : KafkaTestContainersUtils() {
         val addressFile = folderRule.newFile(addressPath)
         addressFile.writeText(addressSchema)
         val addressReferenceName = "Address"
-        val addressSubject = "$subjectName-address-mixed"
-        client.register(addressSubject, parser.parseSchemaFromFile(addressSubject, addressFile.path, listOf(), listOf()))
+        val addressSubject = Subject("$subjectName-address-mixed",addressFile.path, type.toString())
+        client.register(addressSubject.inputSubject, parser.parseSchemaFromFile(addressSubject))
 
         val playerPath = "$type/player.$extension"
-        val playerSubject = "$subjectName-player-mixed"
         val playerFile = folderRule.newFile(playerPath)
         playerFile.writeText(playerSchema)
+        val playerSubject = Subject("$subjectName-player-mixed",playerFile.path, type.toString())
         client.register(
-            playerSubject,
+            playerSubject.inputSubject,
             parser.parseSchemaFromFile(
-                playerSubject,
-                playerFile.path,
-                listOf(),
-                listOf()
+                playerSubject
             )
         )
 

--- a/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
@@ -487,7 +487,7 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
     @Test
     fun `Should download schema that has been normalized`() {
         // Given
-        val subjectName = "test"
+        val subjectName = "test-proto"
 
         client.register(
             subjectName,
@@ -552,8 +552,6 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
           string name = 1;
           string description = 2;
         }""".trimIndent().trim())
-
-        println("test")
     }
 
     private class SchemaArgumentProvider : ArgumentsProvider {

--- a/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskIT.kt
@@ -3,15 +3,13 @@ package com.github.imflog.schema.registry.tasks.download
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.SerializationFeature
-import com.github.imflog.schema.registry.SchemaType
 import com.github.imflog.schema.registry.toSchemaType
 import com.github.imflog.schema.registry.utils.KafkaTestContainersUtils
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.avro.AvroSchema
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+import io.confluent.kafka.schemaregistry.client.rest.entities.*
 import io.confluent.kafka.schemaregistry.json.JsonSchema
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
-import org.apache.avro.Schema
 import org.assertj.core.api.Assertions
 import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testkit.runner.BuildResult
@@ -107,7 +105,7 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
 
         val type = AvroSchema.TYPE
         val schema =  AvroSchema(
-                """{
+            """{
                             "type": "record",
                             "name": "User",
                             "fields": [
@@ -354,10 +352,17 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
                     "type": "record",
                     "name": "User",
                     "fields": [
-                        { "name": "name", "type": "string" }
+                        { "name": "name", "type": "string", "confluent:tags": [ "PII" ] }
                     ]
-                }"""
-            )
+                }""", emptyList(), emptyMap(),
+                Metadata(mapOf(Pair("**.ssn", setOf("PII"))), mapOf(Pair("owner", "Bob Jones"),
+                    Pair("email", "bob@acme.com")),null),
+                RuleSet(null, listOf(
+                    Rule("encryptPII",null,RuleKind.TRANSFORM,RuleMode.WRITEREAD,"ENCRYPT",
+                        setOf("PII"), mapOf(Pair("encrypt.kek.name", "kafka-csfle"),
+                            Pair("encrypt.kms.key.id", "projects/gcp-project/locations/europe-west6/keyRings/gcp-keyring/cryptoKeys/kafka-csfle"),
+                            Pair("encrypt.kms.type", "gcp-kms")),null,null,"ERROR,NONE",false))),
+                null,true),true
         )
 
         buildFile = folderRule.newFile("build.gradle")
@@ -477,6 +482,78 @@ class DownloadTaskIT : KafkaTestContainersUtils() {
         Assertions.assertThat(File(folderRule.root, "src/main/avro/metadata/$libMetadataFile")).exists()
 
         Assertions.assertThat(result?.task(":downloadSchemasTask")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
+
+    @Test
+    fun `Should download schema that has been normalized`() {
+        // Given
+        val subjectName = "test"
+
+        client.register(
+            subjectName,
+            ProtobufSchema(
+                """
+                        syntax = "proto3";
+                        option java_outer_classname = "User";
+                        package foo.v1;
+                        option java_multiple_files = true;
+                        message TestMessage {
+                            string name = 1;
+                            string description = 2;
+                        }
+                    """, emptyList(), emptyMap(),null ,null),
+            true)
+
+        buildFile = folderRule.newFile("build.gradle")
+        buildFile.writeText(
+            """
+            plugins {
+                id 'java'
+                id 'com.github.imflog.kafka-schema-registry-gradle-plugin'
+            }
+
+            import com.github.imflog.schema.registry.tasks.download.MetadataExtension
+            schemaRegistry {
+                url = '$schemaRegistryEndpoint'
+                download {
+                    metadata = new MetadataExtension(true)
+                    subject('$subjectName', '${folderRule.root.absolutePath}/src/main/protobuf/test')
+                }
+            }
+        """
+        )
+
+        // When
+        val result: BuildResult? = GradleRunner.create()
+            .withGradleVersion("6.7.1")
+            .withProjectDir(folderRule.root)
+            .withArguments(DownloadTask.TASK_NAME)
+            .withPluginClasspath()
+            .withDebug(true)
+            .build()
+
+        // Then
+        val schemaFile = "$subjectName.proto"
+        val metadataFile = "$subjectName-metadata.json"
+        Assertions.assertThat(File(folderRule.root, "src/main/protobuf/test/$schemaFile")).exists()
+        Assertions.assertThat(File(folderRule.root, "src/main/protobuf/test/$metadataFile")).exists()
+        Assertions.assertThat(result?.task(":downloadSchemasTask")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        val resultFile = File(folderRule.root, "src/main/protobuf/test/$schemaFile")
+
+        Assertions.assertThat(resultFile.readText().trim()).isEqualTo(
+        """
+        syntax = "proto3";
+        package foo.v1;
+        
+        option java_multiple_files = true;
+        option java_outer_classname = "User";
+        
+        message TestMessage {
+          string name = 1;
+          string description = 2;
+        }""".trimIndent().trim())
+
+        println("test")
     }
 
     private class SchemaArgumentProvider : ArgumentsProvider {

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -1,6 +1,10 @@
 package com.github.imflog.schema.registry
 
+import com.google.gson.Gson
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+import java.io.File
 
 data class Subject(
     val inputSubject: String,
@@ -9,6 +13,9 @@ data class Subject(
 ) {
     val references: MutableList<SchemaReference> = mutableListOf()
     val localReferences: MutableList<LocalReference> = mutableListOf()
+    var metadata: Metadata = Metadata(mutableMapOf(), mutableMapOf(), mutableSetOf())
+    var ruleSet: RuleSet = RuleSet(mutableListOf(), mutableListOf());
+
 
     fun addReference(name: String, subject: String, version: Int): Subject {
         references.add(SchemaReference(name, subject, version))
@@ -25,7 +32,21 @@ data class Subject(
         return this
     }
 
+    fun setMetadata(path: String): Subject {
+        val metadataContent = File(path).readText(Charsets.UTF_8)
+        metadata =  Gson().fromJson(metadataContent, Metadata::class.java)
+        return this
+    }
+
+    fun setRuleSet(path: String): Subject {
+        val ruleSetContent = File(path).readText(Charsets.UTF_8)
+        ruleSet = Gson().fromJson(ruleSetContent, RuleSet::class.java)
+        return this
+    }
+
     // Used for data class destructuring
     operator fun component4() = references
     operator fun component5() = localReferences
+    operator fun component6() = metadata
+    operator fun component7() = ruleSet
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -14,7 +14,8 @@ data class Subject(
     val references: MutableList<SchemaReference> = mutableListOf()
     val localReferences: MutableList<LocalReference> = mutableListOf()
     var metadata: Metadata = Metadata(mutableMapOf(), mutableMapOf(), mutableSetOf())
-    var ruleSet: RuleSet = RuleSet(mutableListOf(), mutableListOf());
+    var ruleSet: RuleSet = RuleSet(mutableListOf(), mutableListOf())
+    var normalize: Boolean = false
 
 
     fun addReference(name: String, subject: String, version: Int): Subject {
@@ -44,9 +45,15 @@ data class Subject(
         return this
     }
 
+    fun setNormalized(normalize: Boolean): Subject {
+        this.normalize = normalize
+        return this
+    }
+
     // Used for data class destructuring
     operator fun component4() = references
     operator fun component5() = localReferences
     operator fun component6() = metadata
     operator fun component7() = ruleSet
+    operator fun component8() = normalize
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/Subject.kt
@@ -13,8 +13,8 @@ data class Subject(
 ) {
     val references: MutableList<SchemaReference> = mutableListOf()
     val localReferences: MutableList<LocalReference> = mutableListOf()
-    var metadata: Metadata = Metadata(mutableMapOf(), mutableMapOf(), mutableSetOf())
-    var ruleSet: RuleSet = RuleSet(mutableListOf(), mutableListOf())
+    var metadata: Metadata? = null
+    var ruleSet: RuleSet? = null
     var normalize: Boolean = false
 
 
@@ -50,10 +50,5 @@ data class Subject(
         return this
     }
 
-    // Used for data class destructuring
-    operator fun component4() = references
-    operator fun component5() = localReferences
-    operator fun component6() = metadata
-    operator fun component7() = ruleSet
-    operator fun component8() = normalize
+
 }

--- a/src/main/kotlin/com/github/imflog/schema/registry/parser/SchemaParser.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/parser/SchemaParser.kt
@@ -5,6 +5,8 @@ import com.github.imflog.schema.registry.SchemaParsingException
 import com.github.imflog.schema.registry.SchemaType
 import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import java.io.File
 
@@ -33,6 +35,8 @@ abstract class SchemaParser(
         schemaPath: String,
         remoteReferences: List<SchemaReference>,
         localReferences: List<LocalReference>,
+        metadata: Metadata,
+        ruleSet: RuleSet
     ): ParsedSchema {
         val schemaContent = rootDir.resolve(schemaPath).readText()
         val parsedLocalSchemaString = if (localReferences.isNotEmpty()) {
@@ -40,7 +44,7 @@ abstract class SchemaParser(
         } else schemaContent
 
         return client
-            .parseSchema(schemaType.registryType, parsedLocalSchemaString, remoteReferences)
+            .parseSchema(schemaType.registryType, parsedLocalSchemaString, remoteReferences, metadata,ruleSet)
             .orElseThrow { SchemaParsingException(subject, schemaType) }
     }
 

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -21,7 +21,7 @@ class CompatibilityTaskAction(
 
     fun run(): Int {
         var errorCount = 0
-        for ((subject, path, type, remoteReferences, localReferences) in subjects) {
+        for ((subject, path, type, remoteReferences, localReferences, metadata, ruleSet) in subjects) {
             logger.debug("Loading schema for subject($subject) from $path.")
             val isCompatible = try {
                 val parsedSchema = SchemaParser
@@ -30,7 +30,7 @@ class CompatibilityTaskAction(
                         subject,
                         path,
                         remoteReferences,
-                        localReferences
+                        localReferences, metadata , ruleSet
                     )
                 val isCompatible = client.testCompatibility(subject, parsedSchema)
                 if (!isCompatible) {

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/compatibility/CompatibilityTaskAction.kt
@@ -21,21 +21,16 @@ class CompatibilityTaskAction(
 
     fun run(): Int {
         var errorCount = 0
-        for ((subject, path, type, remoteReferences, localReferences, metadata, ruleSet) in subjects) {
-            logger.debug("Loading schema for subject($subject) from $path.")
+        subjects.forEach { subject ->
+            logger.debug("Loading schema for subject(${subject.inputSubject}) from ${subject.file}.")
             val isCompatible = try {
                 val parsedSchema = SchemaParser
-                    .provide(type.toSchemaType(), client, rootDir)
-                    .parseSchemaFromFile(
-                        subject,
-                        path,
-                        remoteReferences,
-                        localReferences, metadata , ruleSet
-                    )
-                val isCompatible = client.testCompatibility(subject, parsedSchema)
+                    .provide(subject.type.toSchemaType(), client, rootDir)
+                    .parseSchemaFromFile(subject)
+                val isCompatible = client.testCompatibility(subject.inputSubject, parsedSchema)
                 if (!isCompatible) {
                     try {
-                        client.testCompatibilityVerbose(subject, parsedSchema).forEach {
+                        client.testCompatibilityVerbose(subject.inputSubject, parsedSchema).forEach {
                             logger.error("Returned errors : $it")
                         }
                     } catch (_: Exception) {
@@ -56,9 +51,9 @@ class CompatibilityTaskAction(
                 }
             }
             if (isCompatible) {
-                logger.infoIfNotQuiet("Schema $path is compatible with subject: $subject")
+                logger.infoIfNotQuiet("Schema ${subject.file} is compatible with subject: ${subject.inputSubject}")
             } else {
-                logger.error("Schema $path is not compatible with subject: $subject")
+                logger.error("Schema ${subject.file} is not compatible with subject: ${subject.inputSubject}")
                 errorCount++
             }
         }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -29,9 +29,9 @@ class RegisterTaskAction(
     fun run(): Int {
         var errorCount = 0
         writeOutputFileHeader()
-        subjects.forEach { (subject, path, type, references: List<SchemaReference>, localReferences, metaData, ruleSet) ->
+        subjects.forEach { (subject, path, type, references: List<SchemaReference>, localReferences, metaData, ruleSet, normalize) ->
             try {
-                val schemaId = registerSchema(subject, path, type.toSchemaType(), references, localReferences, metaData, ruleSet)
+                val schemaId = registerSchema(subject, path, type.toSchemaType(), references, localReferences, metaData, ruleSet, normalize)
                 writeRegisteredSchemaOutput(subject, path, schemaId)
             } catch (e: Exception) {
                 logger.error("Could not register schema for '$subject'", e)
@@ -48,13 +48,14 @@ class RegisterTaskAction(
         references: List<SchemaReference>,
         localReferences: List<LocalReference>,
         metadata: Metadata,
-        ruleSet: RuleSet
+        ruleSet: RuleSet,
+        normalize: Boolean
     ): Int {
         val parsedSchema = SchemaParser
             .provide(type, client, rootDir)
             .parseSchemaFromFile(subject, path, references, localReferences, metadata, ruleSet)
         logger.infoIfNotQuiet("Registering $subject (from $path)")
-        val schemaId = client.register(subject, parsedSchema)
+        val schemaId = client.register(subject, parsedSchema, normalize)
         logger.infoIfNotQuiet("$subject (from $path) has been registered with id $schemaId")
         return schemaId
     }

--- a/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
+++ b/src/main/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskAction.kt
@@ -29,10 +29,10 @@ class RegisterTaskAction(
     fun run(): Int {
         var errorCount = 0
         writeOutputFileHeader()
-        subjects.forEach { (subject, path, type, references: List<SchemaReference>, localReferences, metaData, ruleSet, normalize) ->
+        subjects.forEach { subject ->
             try {
-                val schemaId = registerSchema(subject, path, type.toSchemaType(), references, localReferences, metaData, ruleSet, normalize)
-                writeRegisteredSchemaOutput(subject, path, schemaId)
+                val schemaId = registerSchema(subject)
+                writeRegisteredSchemaOutput(subject.inputSubject,subject.file, schemaId)
             } catch (e: Exception) {
                 logger.error("Could not register schema for '$subject'", e)
                 errorCount++
@@ -42,21 +42,14 @@ class RegisterTaskAction(
     }
 
     private fun registerSchema(
-        subject: String,
-        path: String,
-        type: SchemaType,
-        references: List<SchemaReference>,
-        localReferences: List<LocalReference>,
-        metadata: Metadata,
-        ruleSet: RuleSet,
-        normalize: Boolean
+        subject: Subject
     ): Int {
         val parsedSchema = SchemaParser
-            .provide(type, client, rootDir)
-            .parseSchemaFromFile(subject, path, references, localReferences, metadata, ruleSet)
-        logger.infoIfNotQuiet("Registering $subject (from $path)")
-        val schemaId = client.register(subject, parsedSchema, normalize)
-        logger.infoIfNotQuiet("$subject (from $path) has been registered with id $schemaId")
+            .provide(subject.type.toSchemaType(), client, rootDir)
+            .parseSchemaFromFile(subject)
+        logger.infoIfNotQuiet("Registering $subject (from $subject.file)")
+        val schemaId = client.register(subject.inputSubject, parsedSchema, subject.normalize)
+        logger.infoIfNotQuiet("$subject (from $subject.file) has been registered with id $schemaId")
         return schemaId
     }
 

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/download/DownloadTaskActionTest.kt
@@ -468,7 +468,6 @@ class DownloadTaskActionTest {
         val testSubject = "test"
         val testLibSubject = "test_lib"
         val outputDir = "src/main/avro/external"
-        val metadataDir = "src/main/avro/metadata"
 
         val registryClient = MockSchemaRegistryClient(listOf(AvroSchemaProvider()))
 

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -337,6 +337,7 @@ class RegisterTaskActionTest {
         val subjects = listOf(
             Subject("test", "${schemaPath}testSubject.avsc", "AVRO")
                 .addLocalReference("B", "${schemaPath}testType.avsc")
+                .setRuleSet("${schemaPath}testRuleSet.json")
         )
 
         // When

--- a/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
+++ b/src/test/kotlin/com/github/imflog/schema/registry/tasks/register/RegisterTaskActionTest.kt
@@ -337,7 +337,6 @@ class RegisterTaskActionTest {
         val subjects = listOf(
             Subject("test", "${schemaPath}testSubject.avsc", "AVRO")
                 .addLocalReference("B", "${schemaPath}testType.avsc")
-                .setRuleSet("${schemaPath}testRuleSet.json")
         )
 
         // When

--- a/src/test/resources/testMetadata.json
+++ b/src/test/resources/testMetadata.json
@@ -1,0 +1,9 @@
+{
+  "tags": {
+    "**.ssn": [ "PII" ]
+  },
+  "properties": {
+    "owner": "Bob Jones",
+    "email": "bob@acme.com"
+  }
+}

--- a/src/test/resources/testRuleSet.json
+++ b/src/test/resources/testRuleSet.json
@@ -1,0 +1,19 @@
+{
+  "domainRules": [
+    {
+      "name": "encryptPII",
+      "kind": "TRANSFORM",
+      "type": "ENCRYPT",
+      "mode": "WRITEREAD",
+      "tags": [
+        "PII"
+      ],
+      "params": {
+        "encrypt.kek.name": "kafka-csfle",
+        "encrypt.kms.key.id": "projects/gcp-project/locations/europe-west6/keyRings/gcp-keyring/cryptoKeys/kafka-csfle",
+        "encrypt.kms.type": "gcp-kms"
+      },
+      "onFailure": "ERROR,NONE"
+    }
+  ]
+}

--- a/src/test/resources/testSimpleSubject.avsc
+++ b/src/test/resources/testSimpleSubject.avsc
@@ -4,12 +4,8 @@
   "namespace": "com.mycompany",
   "fields": [
     {
-      "name": "nested",
-      "type": "B"
-    },
-    {
-      "name": "nested1",
-      "type": "B"
+      "name": "foo",
+      "type": "string"
     }
   ]
 }

--- a/src/test/resources/testSubjectWithTag.avsc
+++ b/src/test/resources/testSubjectWithTag.avsc
@@ -4,12 +4,9 @@
   "namespace": "com.mycompany",
   "fields": [
     {
-      "name": "nested",
-      "type": "B"
-    },
-    {
-      "name": "nested1",
-      "type": "B"
+      "name": "ssn",
+      "type": "string",
+      "confluent:tags": [ "PII" ]
     }
   ]
 }


### PR DESCRIPTION
Adding support for subject metadata, rulesets and schema normalisation.

This is also supported in the maven plugin. 

What I did is a very rudimentary implementation, if you have any ideas. I am happy to have a look and modify the code. 

Referencing a file, is an easy way, else I am afraid that the Gradle extension will become to complicated. 

Also my Kotlin experience is limited. 