### PR TITLE
chore: add one more version to confluent matrix, default to latest in tests

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -14,7 +14,8 @@ jobs:
         kafka_version: [
           "6.2.6",
           "7.2.2",
-          "7.3.1"
+          "7.3.1",
+          "7.6.0"
         ]
     steps:
       - uses: "actions/checkout@v3"

--- a/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
+++ b/src/integration/kotlin/com/github/imflog/schema/registry/utils/KafkaTestContainersUtils.kt
@@ -17,7 +17,7 @@ abstract class KafkaTestContainersUtils {
     companion object {
         private const val SCHEMA_REGISTRY_INTERNAL_PORT = 8081
 
-        private val CONFLUENT_VERSION = System.getenv().getOrDefault("KAFKA_VERSION", "7.3.1")
+        private val CONFLUENT_VERSION = System.getenv().getOrDefault("KAFKA_VERSION", "7.6.0")
         private val KAFKA_NETWORK_ALIAS = "kafka-${CONFLUENT_VERSION}"
 
         private val network: Network = Network.newNetwork()


### PR DESCRIPTION
Fixes #172