### PR TITLE
fix(parser): Fix support for local recursive types in Avro schemas

### DIFF
--- a/src/test/resources/testRecursiveSubject.avsc
+++ b/src/test/resources/testRecursiveSubject.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "A",
+  "namespace": "com.mycompany",
+  "fields": [
+    {
+      "name": "myB",
+      "type": "B"
+    },
+    {
+      "name": "myList",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    }
+  ]
+}

--- a/src/test/resources/testRecursiveType.avsc
+++ b/src/test/resources/testRecursiveType.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "B",
+  "namespace": "com.mycompany",
+  "fields": [
+    {
+      "name": "foo",
+      "type": "string"
+    },
+    {
+      "name": "child",
+      "type": "com.mycompany.B"
+    }
+  ]
+}


### PR DESCRIPTION
Implement handling of local recursive types in the AvroSchemaParser. This includes changes to the resolveReferences function and adds a new test case to ensure proper resolution of schemas containing recursive types.